### PR TITLE
Move small components to components/lib with index.js

### DIFF
--- a/components/ImageForm.js
+++ b/components/ImageForm.js
@@ -1,32 +1,7 @@
 import { uploadImage, publicImageURL } from '../lib/media'
 import { useState, useEffect } from 'react'
-import { CloseButton } from './Modal'
+import { CopyInput, CloseButton } from './lib'
 import { useForm } from 'react-hook-form'
-
-export const CopyInput = ({ val }) => {
-  const [status, setStatus] = useState('default')
-  const copyVal = val => {
-    navigator.clipboard.writeText(val)
-    setStatus('confirming')
-    setTimeout(() => setStatus('default'), 3000)
-  }
-  return (
-    <div className="flex flex-row w-full gap-2">
-      <input
-        className="truncate copy-input text-left float-left"
-        disabled
-        dir="rtl"
-        value={val}
-      />
-      <a
-        onClick={() => copyVal(val)}
-        className="float-right button small outline"
-      >
-        {status === 'default' ? 'copy' : 'done!'}
-      </a>
-    </div>
-  )
-}
 
 const UploadSVG = () => (
   <svg

--- a/components/LoginForm.js
+++ b/components/LoginForm.js
@@ -3,8 +3,8 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useForm } from 'react-hook-form'
 import { useSession, postLogin } from '../lib/auth'
-import ErrorList from './ErrorList'
-import Modal, { AlertBox } from './Modal'
+import Modal from './Modal'
+import { AlertBox, ErrorList } from './lib'
 
 export function LoginChallenge() {
   const { session } = useSession()

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import { useSession } from '../lib/auth'
-import { Overlay } from './Modal'
+import { Overlay } from './lib'
 
 export default function Menu() {
   const [isOpen, setIsOpen] = useState()

--- a/components/Modal.js
+++ b/components/Modal.js
@@ -1,39 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-
-export const Overlay = ({ close, children }) => (
-  <div
-    className="z-20 bg-black bg-opacity-50 px-2 pt-10 fixed top-0 left-0 right-0 bottom-0"
-    onClick={close}
-  >
-    {children}
-  </div>
-)
-
-export const CloseButton = ({ close }) => (
-  <button
-    onClick={e => {
-      e.preventDefault()
-      close(e)
-    }}
-    className="py-1 px-2 absolute top-2 right-3 text-xs text-gray-500 flex place-items-center"
-  >
-    close&nbsp;
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className="h-4 w-4"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M6 18L18 6M6 6l12 12"
-      />
-    </svg>
-  </button>
-)
+import { CloseButton, Overlay } from '../components/lib'
 
 export default function Modal({ showing, children }) {
   const [isShowing, setIsShowing] = useState(showing || false)
@@ -64,14 +30,4 @@ export default function Modal({ showing, children }) {
       </div>
     </Overlay>
   ) : null
-}
-
-export function AlertBox({ type, children }) {
-  const classes =
-    type === 'success'
-      ? 'border-green-400 text-green-800 bg-green-200'
-      : // type === 'complete' ?
-        'text-gray-600'
-  // : ''
-  return <div className={`border rounded p-10 py-6 ${classes}`}>{children}</div>
 }

--- a/components/Post.js
+++ b/components/Post.js
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import PrintMarkdown from './PrintMarkdown'
+import { PrintMarkdown } from './lib'
 
 const PostLoading = () => (
   <>

--- a/components/PrintMarkdown.js
+++ b/components/PrintMarkdown.js
@@ -1,7 +1,0 @@
-import unified from 'unified'
-import parse from 'remark-parse'
-import remark2react from 'remark-react'
-
-export default function PrintMarkdown({ markdown }) {
-  return unified().use(parse).use(remark2react).processSync(markdown).result
-}

--- a/components/lib/AlertBox.js
+++ b/components/lib/AlertBox.js
@@ -1,0 +1,9 @@
+const AlertBox = ({ type, children }) => {
+  const classes =
+    type === 'success'
+      ? 'border-green-400 text-green-800 bg-green-200'
+      : 'text-gray-600'
+  return <div className={`border rounded p-10 py-6 ${classes}`}>{children}</div>
+}
+
+export default AlertBox

--- a/components/lib/CloseButton.js
+++ b/components/lib/CloseButton.js
@@ -1,0 +1,27 @@
+const CloseButton = ({ close, text = 'close' }) => (
+  <button
+    onClick={e => {
+      e.preventDefault()
+      close(e)
+    }}
+    className="py-1 px-2 absolute top-2 right-3 text-xs text-gray-500 flex place-items-center"
+  >
+    {text}&nbsp;
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-4 w-4"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M6 18L18 6M6 6l12 12"
+      />
+    </svg>
+  </button>
+)
+
+export default CloseButton

--- a/components/lib/CopyInput.js
+++ b/components/lib/CopyInput.js
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+const CopyInput = ({ val }) => {
+  const [status, setStatus] = useState('default')
+  const copyVal = val => {
+    navigator.clipboard.writeText(val)
+    setStatus('confirming')
+    setTimeout(() => setStatus('default'), 3000)
+  }
+
+  return (
+    <div className="flex flex-row w-full gap-2">
+      <input
+        className="truncate copy-input text-left float-left"
+        disabled
+        dir="rtl"
+        value={val}
+      />
+      <a
+        onClick={() => copyVal(val)}
+        className="float-right button small outline"
+      >
+        {status === 'default' ? 'copy' : 'done!'}
+      </a>
+    </div>
+  )
+}
+
+export default CopyInput

--- a/components/lib/DateSpan.js
+++ b/components/lib/DateSpan.js
@@ -1,4 +1,4 @@
-export default function DateSpan({ dateText }) {
+const DateSpan = ({ dateText }) => {
   const date = new Date(dateText)
   const output = date.toLocaleString('en-IN', {
     weekday: 'long',
@@ -9,3 +9,5 @@ export default function DateSpan({ dateText }) {
 
   return <time dateTime={dateText}>{output}</time>
 }
+
+export default DateSpan

--- a/components/lib/ErrorList.js
+++ b/components/lib/ErrorList.js
@@ -1,5 +1,5 @@
-export default function ErrorList({ summary, error, errors }) {
-  return !error && !errors?.length ? null : (
+const ErrorList = ({ summary, error, errors }) =>
+  !error && !errors?.length ? null : (
     <div>
       {summary ? <p className="font-bold text-red-600">{summary}</p> : null}
       <ul className="pl-5 text-red-600 list-disc">
@@ -8,4 +8,5 @@ export default function ErrorList({ summary, error, errors }) {
       </ul>
     </div>
   )
-}
+
+export default ErrorList

--- a/components/lib/Overlay.js
+++ b/components/lib/Overlay.js
@@ -1,0 +1,10 @@
+const Overlay = ({ close, children }) => (
+  <div
+    className="z-20 bg-black bg-opacity-50 px-2 pt-10 fixed top-0 left-0 right-0 bottom-0"
+    onClick={close}
+  >
+    {children}
+  </div>
+)
+
+export default Overlay

--- a/components/lib/PrintMarkdown.js
+++ b/components/lib/PrintMarkdown.js
@@ -1,0 +1,8 @@
+import unified from 'unified'
+import parse from 'remark-parse'
+import remark2react from 'remark-react'
+
+const PrintMarkdown = ({ markdown }) =>
+  unified().use(parse).use(remark2react).processSync(markdown).result
+
+export default PrintMarkdown

--- a/components/lib/index.js
+++ b/components/lib/index.js
@@ -1,0 +1,17 @@
+import AlertBox from './AlertBox'
+import CloseButton from './CloseButton'
+import CopyInput from './CopyInput'
+import DateSpan from './DateSpan'
+import ErrorList from './ErrorList'
+import Overlay from './Overlay'
+import PrintMarkdown from './PrintMarkdown'
+
+export {
+  AlertBox,
+  CloseButton,
+  CopyInput,
+  DateSpan,
+  ErrorList,
+  Overlay,
+  PrintMarkdown,
+}

--- a/pages/logout.js
+++ b/pages/logout.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Layout from '../components/Layout'
-import { AlertBox } from '../components/Modal'
+import { AlertBox } from '../components/lib'
 import { postLogout } from '../lib/auth'
 
 export default function Logout() {

--- a/pages/media/new.js
+++ b/pages/media/new.js
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import Layout from '../../components/Layout'
 import { LoginChallenge } from '../../components/LoginForm'
-import ImageForm, { CopyInput } from '../../components/ImageForm'
+import ImageForm from '../../components/ImageForm'
+import { CopyInput } from '../../components/lib'
 
 export default function New() {
   const [imageURL, setImageURL] = useState()

--- a/pages/posts/[slug]/edit.js
+++ b/pages/posts/[slug]/edit.js
@@ -6,7 +6,7 @@ import { fetchOnePost, updateOnePost } from '../../../lib/posts'
 import Layout from '../../../components/Layout'
 import { LoginChallenge } from '../../../components/LoginForm'
 import { useSession } from '../../../lib/auth'
-import ErrorList from '../../../components/ErrorList'
+import { ErrorList } from '../../../components/lib'
 import {
   InputTitle,
   InputContent,

--- a/pages/posts/[slug]/index.js
+++ b/pages/posts/[slug]/index.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import Layout from '../../../components/Layout'
-import DateSpan from '../../../components/DateSpan'
+import { DateSpan } from '../../../components/lib'
 import { PostArticle } from '../../../components/Post'
 import { useSession } from '../../../lib/auth'
 import { fetchPostList, fetchOnePost } from '../../../lib/posts'

--- a/pages/posts/drafts.js
+++ b/pages/posts/drafts.js
@@ -3,7 +3,7 @@ import useSWR from 'swr'
 import PostList from '../../components/PostList'
 import Layout from '../../components/Layout'
 import { LoginChallenge } from '../../components/LoginForm'
-import ErrorList from '../../components/ErrorList'
+import { ErrorList } from '../../components/lib'
 import { useSession } from '../../lib/auth'
 import { fetchDraftPosts } from '../../lib/posts'
 

--- a/pages/posts/new.js
+++ b/pages/posts/new.js
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router'
 import { useForm } from 'react-hook-form'
 import Layout from '../../components/Layout'
 import { LoginChallenge } from '../../components/LoginForm'
-import ErrorList from '../../components/ErrorList'
+import { ErrorList } from '../../components/lib'
 import {
   InputTitle,
   InputContent,


### PR DESCRIPTION
The following highly re-usable, not-very-context-specific components have been moved to the folder `components/lib`: AlertBox, CloseButton, CopyInput, DateSpan, ErrorList, Overlay. This folder is for small, self-contained components. 

There is an `index.js` file that imports and exports everything in the folder, so that other pages and components can write imports like: `import { AlertBox, DateSpan, ErrorList } from './lib'`