### PR TITLE
Add inline image upload to post content editor

### DIFF
--- a/app/(private)/posts/[slug]/edit/page.tsx
+++ b/app/(private)/posts/[slug]/edit/page.tsx
@@ -53,6 +53,7 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 		watch,
 		handleSubmit,
 		setValue,
+		getValues,
 		reset,
 		formState: { errors, isDirty },
 	} = useForm<PostUpdate>({
@@ -89,7 +90,11 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 					<fieldset disabled={!session || updatePostMutation.isPending}>
 						<InputTitle register={register} error={errors.title} />
 						<InputExcerpt register={register} />
-						<InputContent register={register} />
+						<InputContent
+							register={register}
+							setValue={setValue}
+							getValues={getValues}
+						/>
 						<InputImage
 							register={register}
 							error={errors.image}

--- a/app/(private)/posts/new/page.tsx
+++ b/app/(private)/posts/new/page.tsx
@@ -20,6 +20,7 @@ export default function Page() {
 		register,
 		handleSubmit,
 		setValue,
+		getValues,
 		formState: { errors, isSubmitting },
 	} = useForm()
 	const [formError, setFormError] = useState<PostgrestError | null>(null)
@@ -50,7 +51,11 @@ export default function Page() {
 						error={errors.image}
 						setImageValue={(v: string) => setValue('image', v)}
 					/>
-					<InputContent register={register} />
+					<InputContent
+						register={register}
+						setValue={setValue}
+						getValues={getValues}
+					/>
 
 					<div className="flex justify-between">
 						<Link href="/" className={buttonStyles({ variant: 'outlines' })}>

--- a/components/image-form.tsx
+++ b/components/image-form.tsx
@@ -1,26 +1,9 @@
 import type { ChangeEvent } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import supabase from '@/app/supabase-client'
-import { imageUrlify } from '@/lib/utils'
+import { imageUrlify, filenameFromFile } from '@/lib/utils'
 import Image from 'next/image'
 import { ErrorList } from './lib'
-
-const filenameFromFile = (file: File) => {
-	// returns a string like pic-of-my-cat-1a4d06.jpg
-
-	// separate the file extension so we can re-append it at the end 'jpg'
-	let nameparts = file.name.split('.')
-	const ext = nameparts.pop()
-
-	// rejoin the remaining parts in case of 'pic.of.my.cat.jpg'
-	const slug = nameparts.join('.').replaceAll(' ', '-')
-
-	// a hash like '1a4d06' from the image timestamp to track uniqueness
-	const timeHash = Math.round(file.lastModified * 0.000001).toString(16)
-
-	const path = `${slug}-${timeHash}.${ext}`
-	return path
-}
 
 interface ImageInputProps {
 	confirmedURL: string

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -33,3 +33,20 @@ export function imageUrlify(path: string | null): string {
 		? ''
 		: supabase.storage.from('images').getPublicUrl(path).data?.publicUrl
 }
+
+export function filenameFromFile(file: File) {
+	// returns a string like pic-of-my-cat-1a4d06.jpg
+
+	// separate the file extension so we can re-append it at the end 'jpg'
+	let nameparts = file.name.split('.')
+	const ext = nameparts.pop()
+
+	// rejoin the remaining parts in case of 'pic.of.my.cat.jpg'
+	const slug = nameparts.join('.').replaceAll(' ', '-')
+
+	// a hash like '1a4d06' from the image timestamp to track uniqueness
+	const timeHash = Math.round(file.lastModified * 0.000001).toString(16)
+
+	const path = `${slug}-${timeHash}.${ext}`
+	return path
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to upload images directly within the post content editor and insert them as markdown at the cursor position, improving the content creation workflow.

## Key Changes
- **Image upload in content editor**: Added image upload functionality to the `InputContent` component with a file input button that accepts multiple images
- **Cursor-aware insertion**: Images are inserted as markdown syntax (`![alt](url)`) at the current cursor position in the textarea, with automatic newline handling for proper formatting
- **Extracted utility function**: Moved `filenameFromFile` from `image-form.tsx` to `lib/utils.ts` to enable reuse across components
- **Form integration**: Updated both post creation and edit pages to pass `setValue` and `getValues` from react-hook-form to the `InputContent` component
- **Error handling**: Added error display using the existing `ErrorList` component for upload failures
- **Loading state**: Shows "Uploading..." indicator while images are being processed

## Implementation Details
- Uses `@tanstack/react-query` mutation for async image uploads to Supabase storage
- Maintains textarea ref to access cursor position and focus management
- Automatically generates alt text from filename (removes extension, replaces hyphens/underscores with spaces)
- Properly handles edge cases like newline insertion to maintain markdown formatting
- Resets file input after selection to allow re-uploading the same file

https://claude.ai/code/session_01D8KdQF8HmwepBWozbn9kDq