### PR TITLE
Add ISR and server-side cache revalidation for posts

### DIFF
--- a/app/(private)/posts/[slug]/edit/page.tsx
+++ b/app/(private)/posts/[slug]/edit/page.tsx
@@ -19,6 +19,7 @@ import {
 import { PostArticle } from '@/components/post'
 import { postQueryOptions } from '../use-post'
 import supabase from '@/app/supabase-client'
+import { revalidatePost } from '@/app/actions/revalidate'
 
 export default function Page({ params: { slug } }) {
 	const { data, error, isPending } = useQuery({ ...postQueryOptions(slug) })
@@ -74,6 +75,7 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 		onSuccess: (data) => {
 			reset(data)
 			queryClient.setQueryData(['post', initialData.slug], data)
+			revalidatePost(data.slug)
 		},
 	})
 

--- a/app/(private)/posts/[slug]/use-post.ts
+++ b/app/(private)/posts/[slug]/use-post.ts
@@ -5,7 +5,5 @@ export const postQueryOptions = (slug: string) =>
 	queryOptions({
 		queryKey: ['post', slug],
 		queryFn: async ({ queryKey }) => await fetchOnePost(queryKey[1]),
-		refetchOnWindowFocus: false,
-		refetchOnReconnect: false,
-		refetchOnMount: false,
+		staleTime: 30_000,
 	})

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -6,6 +6,8 @@ import IffLoggedIn from '../iff-logged-in'
 import { fetchPostList } from '@/lib/posts'
 import { buttonStyles } from '@/components/lib'
 
+export const revalidate = 60
+
 export const metadata: Metadata = {
 	title: 'em snook web site',
 	description: 'My personal space to jot things down',

--- a/app/(public)/posts/[slug]/page.tsx
+++ b/app/(public)/posts/[slug]/page.tsx
@@ -9,6 +9,8 @@ import Banner from '@/components/banner'
 import { cn } from '@/lib/utils'
 import { Tables } from '@/types/supabase'
 
+export const revalidate = 60
+
 const PostSidebar = ({ post }: { post: Tables<'posts'> }) => {
 	return (
 		<aside className="col-span-1 flex flex-col gap-4 md:pt-10 lg:pt-14 md:text-center">

--- a/app/actions/revalidate.ts
+++ b/app/actions/revalidate.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+export async function revalidatePost(slug: string) {
+	revalidatePath(`/posts/${slug}`)
+	revalidatePath('/')
+}


### PR DESCRIPTION
## Summary
Implement Incremental Static Regeneration (ISR) and server-side cache revalidation to improve performance and ensure fresh content for blog posts.

## Key Changes
- **New server action**: Created `revalidatePost()` in `app/actions/revalidate.ts` to revalidate both individual post pages and the homepage after post updates
- **ISR configuration**: Added `export const revalidate = 60` to public post pages (`app/(public)/posts/[slug]/page.tsx` and `app/(public)/page.tsx`) to enable ISR with 60-second revalidation intervals
- **Query cache optimization**: Updated `postQueryOptions` to use `staleTime: 30_000` instead of disabling all refetch strategies, allowing more granular cache control
- **Post update flow**: Integrated `revalidatePost()` call in the post edit success callback to trigger cache revalidation when posts are updated

## Implementation Details
- The revalidation strategy uses a 30-second client-side stale time paired with 60-second ISR intervals, balancing freshness with performance
- Server-side revalidation is triggered on successful post updates, ensuring the homepage and individual post pages reflect changes immediately
- This approach combines Next.js ISR for static pages with on-demand revalidation for dynamic updates

https://claude.ai/code/session_012XiL3xEjaz4dr2pf87pXQu