### PR TITLE
Move mortality explorer to /stats/mortality, fix error handling

### DIFF
--- a/app/(public)/stats/layout.tsx
+++ b/app/(public)/stats/layout.tsx
@@ -1,0 +1,3 @@
+export default function StatsLayout({ children }) {
+	return <div className="w-full">{children}</div>
+}

--- a/app/(public)/stats/mortality/mortality-explorer.tsx
+++ b/app/(public)/stats/mortality/mortality-explorer.tsx
@@ -288,6 +288,10 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 		return visibleCauses.filter((c) => c.parent_id === parentId).length
 	}
 
+	// Shared styles for the sticky left column label cells
+	const labelCellBase =
+		'sticky left-0 z-10 border-b border-r px-2 py-1 w-[140px] min-w-[140px] max-w-[140px]'
+
 	return (
 		<div>
 			{/* Controls */}
@@ -350,10 +354,7 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 					<thead>
 						{/* Level 1 grouping row */}
 						<tr className="bg-gray-50">
-							<th
-								className="sticky left-0 z-10 bg-gray-50 border-b border-r px-2 py-1"
-								rowSpan={2}
-							>
+							<th className={`${labelCellBase} bg-gray-50`} rowSpan={2}>
 								<button
 									onClick={() => handleSort('region')}
 									className="font-bold hover:text-cyan-bright"
@@ -414,7 +415,9 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 						</tr>
 						{/* Baseline row */}
 						<tr className="bg-emerald-50">
-							<td className="sticky left-0 z-10 bg-emerald-50 border-b border-r px-2 py-1 font-medium text-emerald-700 text-xs">
+							<td
+								className={`${labelCellBase} bg-emerald-50 font-medium text-emerald-700 text-xs`}
+							>
 								Baseline
 							</td>
 							{visibleCauses.map((cause) => {
@@ -453,11 +456,16 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 										className="bg-gray-100 cursor-pointer hover:bg-gray-200"
 										onClick={() => toggleSuperRegion(sr.id)}
 									>
-										<td className="sticky left-0 z-10 bg-gray-100 border-b border-r px-2 py-1.5 font-bold text-gray-700">
-											<span className="mr-1 text-gray-400 inline-block w-3">
+										<td
+											className={`${labelCellBase} bg-gray-100 py-1.5`}
+											title={sr.name}
+										>
+											<span className="mr-1 text-gray-400 inline-block w-3 flex-shrink-0">
 												{isCollapsed ? '▸' : '▾'}
 											</span>
-											{sr.name}
+											<span className="font-bold text-gray-700 line-clamp-2">
+												{sr.name}
+											</span>
 										</td>
 										{visibleCauses.map((cause) => {
 											// Super-region average (population-weighted would be better, but simple avg for now)
@@ -502,8 +510,13 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 												key={`r-${region.id}`}
 												className="hover:bg-blue-50/50"
 											>
-												<td className="sticky left-0 z-10 bg-white border-b border-r px-2 py-1 pl-6 text-gray-600">
-													{region.name}
+												<td
+													className={`${labelCellBase} bg-white pl-6`}
+													title={region.name}
+												>
+													<span className="text-gray-600 line-clamp-2">
+														{region.name}
+													</span>
 												</td>
 												{visibleCauses.map((cause) => {
 													const value = getCellValue(cause.id, region.id)
@@ -538,7 +551,7 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 					<tfoot>
 						{/* Total excess deaths by cause */}
 						<tr className="bg-gray-50 font-bold">
-							<td className="sticky left-0 z-10 bg-gray-50 border-t-2 border-r px-2 py-1.5">
+							<td className={`${labelCellBase} bg-gray-50 border-t-2`}>
 								Total Excess Deaths
 							</td>
 							{visibleCauses.map((cause) => (
@@ -561,12 +574,12 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 			</div>
 
 			{/* Legend and notes */}
-			<div className="mt-4 grid gap-4 md:grid-cols-2">
+			<div className="mt-4 grid gap-4 md:grid-cols-2 max-w-prose">
 				<div className="text-xs text-gray-500">
 					<p className="font-bold text-gray-700 mb-1">
 						Color scale (per column)
 					</p>
-					<div className="flex gap-2 items-center">
+					<div className="flex gap-2 items-center flex-wrap">
 						<span className="inline-block w-4 h-4 rounded bg-emerald-100 border" />
 						<span>At or below baseline</span>
 						<span className="inline-block w-4 h-4 rounded bg-yellow-100 border" />
@@ -589,7 +602,7 @@ export default function MortalityExplorer({ data }: { data: MortalityData }) {
 			</div>
 
 			{/* Top causes table */}
-			<div className="mt-6">
+			<div className="mt-6 max-w-prose">
 				<h2 className="h4 mb-2">
 					Largest causes of excess mortality (estimated)
 				</h2>

--- a/app/(public)/stats/mortality/page.tsx
+++ b/app/(public)/stats/mortality/page.tsx
@@ -17,14 +17,20 @@ export default async function MortalityPage() {
 	try {
 		data = await fetchMortalityData(2019)
 	} catch (e) {
-		error = e instanceof Error ? e.message : 'Failed to load mortality data'
+		const msg =
+			e instanceof Error
+				? e.message
+				: typeof e === 'object' && e !== null && 'message' in e
+					? String((e as { message: unknown }).message)
+					: 'Unknown error'
+		error = msg
 	}
 
 	return (
-		<main className="container py-6">
-			<div className="mb-6">
+		<main className="py-6">
+			<div className="mb-6 max-w-prose mx-auto px-4">
 				<h1 className="h2">Global Excess Mortality Explorer</h1>
-				<p className="text-gray-600 mt-2 max-w-prose">
+				<p className="text-gray-600 mt-2">
 					Approximate age-standardized death rates per 100,000 by GBD region and
 					cause (2019). Rates are compared against a &ldquo;baseline&rdquo; —
 					the best-performing region for each cause — to show excess preventable
@@ -37,19 +43,21 @@ export default async function MortalityPage() {
 			</div>
 
 			{error ? (
-				<div className="rounded border border-red-300 bg-red-50 p-4 text-red-800">
-					<p className="font-bold">Error loading data</p>
-					<p className="text-sm mt-1">{error}</p>
-					<p className="text-sm mt-2 text-gray-600">
-						The mortality schema may not be set up yet. Run the Supabase
-						migration first:
-					</p>
-					<code className="block mt-1 text-xs bg-gray-100 p-2 rounded">
-						supabase db push
-					</code>
+				<div className="max-w-prose mx-auto px-4">
+					<div className="rounded border border-red-300 bg-red-50 p-4 text-red-800">
+						<p className="font-bold">Error loading data</p>
+						<p className="text-sm mt-1">{error}</p>
+						<p className="text-sm mt-2 text-gray-600">
+							Make sure the <code>mortality</code> schema is added to the
+							exposed schemas in your Supabase project&rsquo;s API settings
+							(Project Settings &rarr; API &rarr; Exposed schemas).
+						</p>
+					</div>
 				</div>
 			) : data ? (
-				<MortalityExplorer data={data} />
+				<div className="px-4">
+					<MortalityExplorer data={data} />
+				</div>
 			) : null}
 		</main>
 	)

--- a/lib/mortality.ts
+++ b/lib/mortality.ts
@@ -11,11 +11,23 @@ import type {
 
 const mortality = () => supabase.schema('mortality')
 
+function throwOnError(error: {
+	message: string
+	details?: string
+	hint?: string
+	code?: string
+}) {
+	const parts = [error.message]
+	if (error.details) parts.push(error.details)
+	if (error.hint) parts.push(error.hint)
+	throw new Error(parts.join(' — '))
+}
+
 export async function fetchCauses(level?: number): Promise<Cause[]> {
 	let query = mortality().from('causes').select('*').order('sort_order')
 	if (level) query = query.eq('gbd_level', level)
 	const { data, error } = await query
-	if (error) throw error
+	if (error) throwOnError(error)
 	return data as Cause[]
 }
 
@@ -24,7 +36,7 @@ export async function fetchSuperRegions(): Promise<SuperRegion[]> {
 		.from('super_regions')
 		.select('*')
 		.order('sort_order')
-	if (error) throw error
+	if (error) throwOnError(error)
 	return data as SuperRegion[]
 }
 
@@ -33,7 +45,7 @@ export async function fetchRegions(): Promise<Region[]> {
 		.from('regions')
 		.select('*')
 		.order('sort_order')
-	if (error) throw error
+	if (error) throwOnError(error)
 	return data as Region[]
 }
 
@@ -41,7 +53,7 @@ export async function fetchRates(year?: number): Promise<Rate[]> {
 	let query = mortality().from('rates').select('*')
 	if (year) query = query.eq('year', year)
 	const { data, error } = await query
-	if (error) throw error
+	if (error) throwOnError(error)
 	return data as Rate[]
 }
 
@@ -49,7 +61,7 @@ export async function fetchBaselines(defaultOnly = true): Promise<Baseline[]> {
 	let query = mortality().from('baselines').select('*')
 	if (defaultOnly) query = query.eq('is_default', true)
 	const { data, error } = await query
-	if (error) throw error
+	if (error) throwOnError(error)
 	return data as Baseline[]
 }
 
@@ -57,7 +69,7 @@ export async function fetchRateMatrix(year?: number): Promise<RateMatrixRow[]> {
 	let query = mortality().from('rate_matrix').select('*')
 	if (year) query = query.eq('year', year)
 	const { data, error } = await query
-	if (error) throw error
+	if (error) throwOnError(error)
 	return data as RateMatrixRow[]
 }
 
@@ -67,7 +79,7 @@ export async function fetchExcessByRegion(
 	let query = mortality().from('excess_by_region').select('*')
 	if (year) query = query.eq('year', year)
 	const { data, error } = await query
-	if (error) throw error
+	if (error) throwOnError(error)
 	return data as ExcessByRegionRow[]
 }
 


### PR DESCRIPTION
- Move route from /mortality to /stats/mortality with a stats layout that allows full-width data tables while constraining prose sections
- Clamp left-side region labels to 2 lines with title hover for full text
- Fix error handling: PostgrestError is not an Error instance, so wrap it properly to surface the actual Supabase error message instead of a generic fallback. The error was likely "The schema must be one of the following: public, storage" — meaning the mortality schema needs to be added to exposed schemas in the Supabase project API settings.

https://claude.ai/code/session_01FiGfn3gpQus8NtjPX71U7o