### PR TITLE
Add Flow: personal activity & wellbeing tracker

### DIFF
--- a/app/(private)/flow/check-in/check-in-form.tsx
+++ b/app/(private)/flow/check-in/check-in-form.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createCheckIn } from '@/lib/flow'
+import ScaleInput from '@/components/flow/scale-input'
+
+const SCALES = [
+	{
+		key: 'anxiety',
+		label: 'Anxiety',
+		labels: ['calm', 'high'] as [string, string],
+	},
+	{
+		key: 'depression',
+		label: 'Depression',
+		labels: ['light', 'heavy'] as [string, string],
+	},
+	{
+		key: 'energy',
+		label: 'Energy',
+		labels: ['drained', 'buzzing'] as [string, string],
+	},
+	{
+		key: 'ease',
+		label: 'Ease',
+		labels: ['struggling', 'easy'] as [string, string],
+	},
+	{
+		key: 'flow',
+		label: 'Flow',
+		labels: ['stuck', 'flowing'] as [string, string],
+	},
+	{
+		key: 'focus',
+		label: 'Focus',
+		labels: ['scattered', 'locked in'] as [string, string],
+	},
+] as const
+
+type ScaleKey = (typeof SCALES)[number]['key']
+
+export default function CheckInForm({ onDone }: { onDone?: () => void }) {
+	const [values, setValues] = useState<Record<ScaleKey, number | null>>({
+		anxiety: null,
+		depression: null,
+		energy: null,
+		ease: null,
+		flow: null,
+		focus: null,
+	})
+	const [notes, setNotes] = useState('')
+	const queryClient = useQueryClient()
+
+	const save = useMutation({
+		mutationFn: () =>
+			createCheckIn({
+				...values,
+				notes: notes || null,
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['flow', 'check-ins'] })
+			onDone?.()
+		},
+	})
+
+	const hasAnyValue = Object.values(values).some((v) => v !== null)
+
+	return (
+		<div className="flex flex-col gap-5">
+			{SCALES.map((scale) => (
+				<div key={scale.key}>
+					<label className="text-sm text-gray-600 mb-1 block">
+						{scale.label}
+					</label>
+					<ScaleInput
+						value={values[scale.key]}
+						onChange={(v) => setValues((prev) => ({ ...prev, [scale.key]: v }))}
+						labels={scale.labels}
+					/>
+				</div>
+			))}
+
+			<div>
+				<label className="text-sm text-gray-600 mb-1 block">Notes</label>
+				<textarea
+					value={notes}
+					onChange={(e) => setNotes(e.target.value)}
+					rows={3}
+					placeholder="Anything on your mind..."
+					className="w-full border rounded-lg px-3 py-2 text-sm focus:border-cyan focus:outline-none bg-transparent"
+				/>
+			</div>
+
+			<button
+				onClick={() => save.mutate()}
+				disabled={save.isPending || !hasAnyValue}
+				className="px-6 py-3 rounded-xl bg-cyan-bright text-white text-lg hover:bg-cyan disabled:opacity-50 self-center"
+			>
+				{save.isPending ? 'Saving...' : 'Save check-in'}
+			</button>
+
+			{save.isSuccess && (
+				<p className="text-green-600 text-sm text-center">Saved</p>
+			)}
+		</div>
+	)
+}

--- a/app/(private)/flow/check-in/check-in-form.tsx
+++ b/app/(private)/flow/check-in/check-in-form.tsx
@@ -67,10 +67,10 @@ export default function CheckInForm({ onDone }: { onDone?: () => void }) {
 	const hasAnyValue = Object.values(values).some((v) => v !== null)
 
 	return (
-		<div className="flex flex-col gap-5">
+		<div className="flow-card-interactive flex flex-col gap-5">
 			{SCALES.map((scale) => (
 				<div key={scale.key}>
-					<label className="text-sm text-gray-600 mb-1 block">
+					<label className="flow-section-heading mb-1 block">
 						{scale.label}
 					</label>
 					<ScaleInput
@@ -82,20 +82,20 @@ export default function CheckInForm({ onDone }: { onDone?: () => void }) {
 			))}
 
 			<div>
-				<label className="text-sm text-gray-600 mb-1 block">Notes</label>
+				<label className="flow-section-heading mb-1 block">Notes</label>
 				<textarea
 					value={notes}
 					onChange={(e) => setNotes(e.target.value)}
 					rows={3}
 					placeholder="Anything on your mind..."
-					className="w-full border rounded-lg px-3 py-2 text-sm focus:border-cyan focus:outline-none bg-transparent"
+					className="w-full border border-flow-border rounded-lg px-3 py-2 text-sm bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 				/>
 			</div>
 
 			<button
 				onClick={() => save.mutate()}
 				disabled={save.isPending || !hasAnyValue}
-				className="px-6 py-3 rounded-xl bg-cyan-bright text-white text-lg hover:bg-cyan disabled:opacity-50 self-center"
+				className="px-6 py-3 rounded-xl bg-cyan-bright text-white text-lg font-display font-bold hover:bg-cyan disabled:opacity-50 self-center shadow-sm"
 			>
 				{save.isPending ? 'Saving...' : 'Save check-in'}
 			</button>

--- a/app/(private)/flow/check-in/page.tsx
+++ b/app/(private)/flow/check-in/page.tsx
@@ -9,7 +9,7 @@ export default function CheckInPage() {
 	return (
 		<div className="flex flex-col gap-6">
 			<h1 className="h2">Check in</h1>
-			<p className="text-gray-500">
+			<p className="text-flow-muted">
 				All optional. Just fill in what feels relevant right now.
 			</p>
 			<CheckInForm onDone={() => router.push('/flow')} />

--- a/app/(private)/flow/check-in/page.tsx
+++ b/app/(private)/flow/check-in/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import CheckInForm from './check-in-form'
+
+export default function CheckInPage() {
+	const router = useRouter()
+
+	return (
+		<div className="flex flex-col gap-6">
+			<h1 className="h2">Check in</h1>
+			<p className="text-gray-500">
+				All optional. Just fill in what feels relevant right now.
+			</p>
+			<CheckInForm onDone={() => router.push('/flow')} />
+		</div>
+	)
+}

--- a/app/(private)/flow/check-in/quick-check.tsx
+++ b/app/(private)/flow/check-in/quick-check.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createCheckIn } from '@/lib/flow'
+import ScaleInput from '@/components/flow/scale-input'
+
+export default function QuickCheck() {
+	const [energy, setEnergy] = useState<number | null>(null)
+	const [mood, setMood] = useState<number | null>(null)
+	const [saved, setSaved] = useState(false)
+	const queryClient = useQueryClient()
+
+	const save = useMutation({
+		mutationFn: () =>
+			createCheckIn({
+				energy,
+				ease: mood,
+				anxiety: null,
+				depression: null,
+				flow: null,
+				focus: null,
+				notes: null,
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['flow', 'check-ins'] })
+			setSaved(true)
+			setTimeout(() => setSaved(false), 2000)
+			setEnergy(null)
+			setMood(null)
+		},
+	})
+
+	if (saved) {
+		return (
+			<div className="px-4 py-3 rounded-xl bg-white border text-center text-sm text-green-600">
+				Noted
+			</div>
+		)
+	}
+
+	return (
+		<div className="flex flex-col gap-3 px-4 py-3 rounded-xl bg-white border">
+			<p className="text-sm text-gray-500">Quick check</p>
+			<div className="grid grid-cols-2 gap-3">
+				<div>
+					<label className="text-xs text-gray-400 mb-1 block">Energy</label>
+					<ScaleInput value={energy} onChange={setEnergy} />
+				</div>
+				<div>
+					<label className="text-xs text-gray-400 mb-1 block">Mood</label>
+					<ScaleInput value={mood} onChange={setMood} />
+				</div>
+			</div>
+			{(energy !== null || mood !== null) && (
+				<button
+					onClick={() => save.mutate()}
+					disabled={save.isPending}
+					className="self-end text-sm px-3 py-1 rounded bg-cyan text-white hover:bg-cyan-bright disabled:opacity-50"
+				>
+					Save
+				</button>
+			)}
+		</div>
+	)
+}

--- a/app/(private)/flow/check-in/quick-check.tsx
+++ b/app/(private)/flow/check-in/quick-check.tsx
@@ -33,22 +33,22 @@ export default function QuickCheck() {
 
 	if (saved) {
 		return (
-			<div className="px-4 py-3 rounded-xl bg-white border text-center text-sm text-green-600">
+			<div className="flow-card text-center text-sm text-green-600">
 				Noted
 			</div>
 		)
 	}
 
 	return (
-		<div className="flex flex-col gap-3 px-4 py-3 rounded-xl bg-white border">
-			<p className="text-sm text-gray-500">Quick check</p>
+		<div className="flow-card-interactive flex flex-col gap-3">
+			<h2 className="flow-section-heading">Quick check</h2>
 			<div className="grid grid-cols-2 gap-3">
 				<div>
-					<label className="text-xs text-gray-400 mb-1 block">Energy</label>
+					<label className="text-xs text-flow-muted mb-1 block">Energy</label>
 					<ScaleInput value={energy} onChange={setEnergy} />
 				</div>
 				<div>
-					<label className="text-xs text-gray-400 mb-1 block">Mood</label>
+					<label className="text-xs text-flow-muted mb-1 block">Mood</label>
 					<ScaleInput value={mood} onChange={setMood} />
 				</div>
 			</div>

--- a/app/(private)/flow/dashboard.tsx
+++ b/app/(private)/flow/dashboard.tsx
@@ -31,12 +31,12 @@ function SessionItem({ session }: { session: PomodoroSession }) {
 		minute: '2-digit',
 	})
 	return (
-		<div className="flex items-center gap-3 py-2 text-sm">
-			<span className="text-gray-400 w-16">{startTime}</span>
+		<div className="flex items-center gap-3 py-2.5 text-sm">
+			<span className="text-flow-muted w-16">{startTime}</span>
 			<span className="flex-1 truncate">
 				{session.intention || 'Untitled session'}
 			</span>
-			<span className="text-gray-400">
+			<span className="text-flow-muted">
 				{formatTimeShort(session.duration_seconds)}
 			</span>
 			<span
@@ -44,7 +44,7 @@ function SessionItem({ session }: { session: PomodoroSession }) {
 					session.status === 'completed'
 						? 'bg-green-100 text-green-600'
 						: session.status === 'abandoned'
-							? 'bg-gray-100 text-gray-400'
+							? 'bg-flow-surface-alt text-flow-muted'
 							: 'bg-cyan/10 text-cyan-bright'
 				}`}
 			>
@@ -70,7 +70,7 @@ function SleepDebtBanner({
 	if (shortNights < 2) return null
 
 	return (
-		<div className="flex items-center justify-between gap-2 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm">
+		<div className="flex items-center justify-between gap-2 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm shadow-sm">
 			<p>
 				You&apos;ve had {shortNights} short nights recently. Tonight, sleep is
 				the priority.
@@ -90,7 +90,7 @@ function GentleReminder({ sessionCount }: { sessionCount: number }) {
 	if (dismissed || sessionCount < 3) return null
 
 	return (
-		<div className="flex items-center justify-between gap-2 px-4 py-3 rounded-xl bg-purple-50 border border-purple-200 text-purple-800 text-sm">
+		<div className="flex items-center justify-between gap-2 px-4 py-3 rounded-xl bg-purple-50 border border-purple-200 text-purple-800 text-sm shadow-sm">
 			<p>
 				{sessionCount} sessions today. Nice work. Maybe check in on something
 				non-work?
@@ -147,7 +147,7 @@ export default function Dashboard() {
 	).length
 
 	return (
-		<div className="flex flex-col gap-6">
+		<div className="flex flex-col gap-5">
 			{/* Sleep debt warning */}
 			<SleepDebtBanner recentSleep={recentSleep} />
 
@@ -158,7 +158,7 @@ export default function Dashboard() {
 			<SleepLog existing={todaySleepLog} />
 
 			{/* Timer section */}
-			<section className="flex flex-col items-center gap-4 py-6">
+			<section className="flow-card-interactive flex flex-col items-center gap-4 py-6">
 				{showComplete ? (
 					<SessionComplete
 						onDone={() => {
@@ -177,8 +177,8 @@ export default function Dashboard() {
 
 			{/* Habits */}
 			{habits.length > 0 && (
-				<section>
-					<h2 className="text-sm text-gray-500 mb-2">Today</h2>
+				<section className="flow-card">
+					<h2 className="flow-section-heading mb-3">Today&apos;s habits</h2>
 					<div className="flex flex-wrap gap-2">
 						{habits.map((habit) => {
 							const log = habitLogs.find(
@@ -201,8 +201,8 @@ export default function Dashboard() {
 
 			{/* Domain status */}
 			{domains.length > 0 && (
-				<section>
-					<h2 className="text-sm text-gray-500 mb-2">Domains</h2>
+				<section className="flow-card">
+					<h2 className="flow-section-heading mb-3">Domains</h2>
 					<div className="flex flex-wrap gap-2">
 						{domains.map((d) => (
 							<DomainBadge key={d.id} domain={d} />
@@ -213,9 +213,9 @@ export default function Dashboard() {
 
 			{/* Today's sessions */}
 			{todaySessions.length > 0 && (
-				<section>
-					<h2 className="text-sm text-gray-500 mb-2">Sessions today</h2>
-					<div className="divide-y">
+				<section className="flow-card">
+					<h2 className="flow-section-heading mb-3">Sessions today</h2>
+					<div className="divide-y divide-flow-border/50">
 						{todaySessions.map((session) => (
 							<SessionItem key={session.id} session={session} />
 						))}

--- a/app/(private)/flow/dashboard.tsx
+++ b/app/(private)/flow/dashboard.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTimerStore } from './timer/timer-store'
+import IntentionForm from './timer/intention-form'
+import TimerDisplay from './timer/timer-display'
+import TimerControls from './timer/timer-controls'
+import SessionComplete from './timer/session-complete'
+import SleepLog from '@/components/flow/sleep-log'
+import HabitToggle from '@/components/flow/habit-toggle'
+import DomainBadge from '@/components/flow/domain-badge'
+import {
+	todaySessionsQuery,
+	recentSleepQuery,
+	habitDefinitionsQuery,
+	todayHabitLogsQuery,
+	domainsQuery,
+} from './use-flow'
+import { toggleHabitLog } from '@/lib/flow'
+import type { PomodoroSession } from '@/types/flow'
+
+function formatTimeShort(seconds: number) {
+	const m = Math.floor(seconds / 60)
+	return `${m}m`
+}
+
+function SessionItem({ session }: { session: PomodoroSession }) {
+	const startTime = new Date(session.started_at).toLocaleTimeString([], {
+		hour: 'numeric',
+		minute: '2-digit',
+	})
+	return (
+		<div className="flex items-center gap-3 py-2 text-sm">
+			<span className="text-gray-400 w-16">{startTime}</span>
+			<span className="flex-1 truncate">
+				{session.intention || 'Untitled session'}
+			</span>
+			<span className="text-gray-400">
+				{formatTimeShort(session.duration_seconds)}
+			</span>
+			<span
+				className={`text-xs px-1.5 py-0.5 rounded ${
+					session.status === 'completed'
+						? 'bg-green-100 text-green-600'
+						: session.status === 'abandoned'
+							? 'bg-gray-100 text-gray-400'
+							: 'bg-cyan/10 text-cyan-bright'
+				}`}
+			>
+				{session.status}
+			</span>
+		</div>
+	)
+}
+
+function SleepDebtBanner({
+	recentSleep,
+}: {
+	recentSleep: { hours_slept: number | null }[]
+}) {
+	const [dismissed, setDismissed] = useState(false)
+	if (dismissed) return null
+
+	const last3 = recentSleep.slice(0, 3)
+	const shortNights = last3.filter(
+		(s) => s.hours_slept != null && s.hours_slept < 6.5,
+	).length
+
+	if (shortNights < 2) return null
+
+	return (
+		<div className="flex items-center justify-between gap-2 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm">
+			<p>
+				You&apos;ve had {shortNights} short nights recently. Tonight, sleep is
+				the priority.
+			</p>
+			<button
+				onClick={() => setDismissed(true)}
+				className="text-amber-400 hover:text-amber-600 shrink-0"
+			>
+				&times;
+			</button>
+		</div>
+	)
+}
+
+function GentleReminder({ sessionCount }: { sessionCount: number }) {
+	const [dismissed, setDismissed] = useState(false)
+	if (dismissed || sessionCount < 3) return null
+
+	return (
+		<div className="flex items-center justify-between gap-2 px-4 py-3 rounded-xl bg-purple-50 border border-purple-200 text-purple-800 text-sm">
+			<p>
+				{sessionCount} sessions today. Nice work. Maybe check in on something
+				non-work?
+			</p>
+			<button
+				onClick={() => setDismissed(true)}
+				className="text-purple-400 hover:text-purple-600 shrink-0"
+			>
+				&times;
+			</button>
+		</div>
+	)
+}
+
+export default function Dashboard() {
+	const status = useTimerStore((s) => s.status)
+	const secondsRemaining = useTimerStore((s) => s.secondsRemaining)
+	const [showComplete, setShowComplete] = useState(false)
+	const queryClient = useQueryClient()
+
+	const { data: todaySessions = [] } = useQuery(todaySessionsQuery())
+	const { data: recentSleep = [] } = useQuery(recentSleepQuery(3))
+	const { data: habits = [] } = useQuery(habitDefinitionsQuery())
+	const { data: habitLogs = [] } = useQuery(todayHabitLogsQuery())
+	const { data: domains = [] } = useQuery(domainsQuery())
+
+	const todaySleepLog = recentSleep.find(
+		(s) => s.date === new Date().toISOString().split('T')[0],
+	)
+
+	const toggleHabit = useMutation({
+		mutationFn: ({ habitId, done }: { habitId: number; done: boolean }) =>
+			toggleHabitLog(habitId, new Date().toISOString().split('T')[0], done),
+		onSuccess: () =>
+			queryClient.invalidateQueries({ queryKey: ['flow', 'habit-logs'] }),
+	})
+
+	// Detect timer completion
+	useEffect(() => {
+		if (
+			(status === 'running' || status === 'break') &&
+			secondsRemaining === 0
+		) {
+			if (status === 'running') {
+				setShowComplete(true)
+			} else {
+				useTimerStore.getState().stopTimer()
+			}
+		}
+	}, [status, secondsRemaining])
+
+	const completedSessionCount = todaySessions.filter(
+		(s) => s.status === 'completed',
+	).length
+
+	return (
+		<div className="flex flex-col gap-6">
+			{/* Sleep debt warning */}
+			<SleepDebtBanner recentSleep={recentSleep} />
+
+			{/* Gentle work-binge reminder */}
+			<GentleReminder sessionCount={completedSessionCount} />
+
+			{/* Sleep log */}
+			<SleepLog existing={todaySleepLog} />
+
+			{/* Timer section */}
+			<section className="flex flex-col items-center gap-4 py-6">
+				{showComplete ? (
+					<SessionComplete
+						onDone={() => {
+							setShowComplete(false)
+							useTimerStore.getState().stopTimer()
+						}}
+					/>
+				) : (
+					<>
+						<IntentionForm />
+						<TimerDisplay />
+						<TimerControls />
+					</>
+				)}
+			</section>
+
+			{/* Habits */}
+			{habits.length > 0 && (
+				<section>
+					<h2 className="text-sm text-gray-500 mb-2">Today</h2>
+					<div className="flex flex-wrap gap-2">
+						{habits.map((habit) => {
+							const log = habitLogs.find(
+								(l) => l.habit_definition_id === habit.id,
+							)
+							return (
+								<HabitToggle
+									key={habit.id}
+									habit={habit}
+									done={log?.done ?? false}
+									onToggle={(done) =>
+										toggleHabit.mutate({ habitId: habit.id, done })
+									}
+								/>
+							)
+						})}
+					</div>
+				</section>
+			)}
+
+			{/* Domain status */}
+			{domains.length > 0 && (
+				<section>
+					<h2 className="text-sm text-gray-500 mb-2">Domains</h2>
+					<div className="flex flex-wrap gap-2">
+						{domains.map((d) => (
+							<DomainBadge key={d.id} domain={d} />
+						))}
+					</div>
+				</section>
+			)}
+
+			{/* Today's sessions */}
+			{todaySessions.length > 0 && (
+				<section>
+					<h2 className="text-sm text-gray-500 mb-2">Sessions today</h2>
+					<div className="divide-y">
+						{todaySessions.map((session) => (
+							<SessionItem key={session.id} session={session} />
+						))}
+					</div>
+				</section>
+			)}
+		</div>
+	)
+}

--- a/app/(private)/flow/domains/domain-card.tsx
+++ b/app/(private)/flow/domains/domain-card.tsx
@@ -14,12 +14,12 @@ export default function DomainCard({
 	)
 
 	return (
-		<div className="flex flex-col gap-2 p-4 rounded-xl bg-white border">
+		<div className="flow-card flex flex-col gap-2">
 			<div className="flex items-center gap-2">
 				{domain.icon && <span className="text-xl">{domain.icon}</span>}
 				<h3 className="font-display font-bold">{domain.name}</h3>
 			</div>
-			<p className="text-sm text-gray-500">
+			<p className="text-sm text-flow-muted">
 				{totalMinutes > 0
 					? `${totalMinutes} minutes this week`
 					: 'No sessions this week'}

--- a/app/(private)/flow/domains/domain-card.tsx
+++ b/app/(private)/flow/domains/domain-card.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import type { LifeDomain, PomodoroSession } from '@/types/flow'
+
+export default function DomainCard({
+	domain,
+	sessions,
+}: {
+	domain: LifeDomain
+	sessions: PomodoroSession[]
+}) {
+	const totalMinutes = Math.round(
+		sessions.reduce((sum, s) => sum + s.duration_seconds, 0) / 60,
+	)
+
+	return (
+		<div className="flex flex-col gap-2 p-4 rounded-xl bg-white border">
+			<div className="flex items-center gap-2">
+				{domain.icon && <span className="text-xl">{domain.icon}</span>}
+				<h3 className="font-display font-bold">{domain.name}</h3>
+			</div>
+			<p className="text-sm text-gray-500">
+				{totalMinutes > 0
+					? `${totalMinutes} minutes this week`
+					: 'No sessions this week'}
+			</p>
+		</div>
+	)
+}

--- a/app/(private)/flow/domains/page.tsx
+++ b/app/(private)/flow/domains/page.tsx
@@ -42,7 +42,7 @@ export default function DomainsPage() {
 					{projects.map((project) => (
 						<div
 							key={project.id}
-							className="flex items-center justify-between p-3 rounded-lg bg-white border"
+							className="flex items-center justify-between p-3 rounded-lg bg-flow-surface border border-flow-border shadow-sm"
 						>
 							<div>
 								<span className="font-medium">{project.name}</span>
@@ -52,7 +52,7 @@ export default function DomainsPage() {
 									</span>
 								)}
 								{project.target_pct != null && (
-									<span className="ml-2 text-xs text-gray-400">
+									<span className="ml-2 text-xs text-flow-muted">
 										target: {project.target_pct}%
 									</span>
 								)}
@@ -60,7 +60,7 @@ export default function DomainsPage() {
 						</div>
 					))}
 					{projects.length === 0 && (
-						<p className="text-sm text-gray-400">No projects yet</p>
+						<p className="text-sm text-flow-muted">No projects yet</p>
 					)}
 				</div>
 			</div>

--- a/app/(private)/flow/domains/page.tsx
+++ b/app/(private)/flow/domains/page.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { domainsQuery, projectsQuery } from '../use-flow'
+import DomainCard from './domain-card'
+import ProjectForm from './project-form'
+
+export default function DomainsPage() {
+	const { data: domains = [] } = useQuery(domainsQuery())
+	const { data: projects = [] } = useQuery(projectsQuery())
+	const [showAddProject, setShowAddProject] = useState(false)
+
+	return (
+		<div className="flex flex-col gap-6">
+			<h1 className="h2">Domains</h1>
+
+			<div className="grid gap-3 sm:grid-cols-2">
+				{domains.map((domain) => (
+					<DomainCard key={domain.id} domain={domain} sessions={[]} />
+				))}
+			</div>
+
+			<div>
+				<div className="flex items-center justify-between mb-3">
+					<h2 className="h3">Projects</h2>
+					<button
+						onClick={() => setShowAddProject(!showAddProject)}
+						className="text-sm text-cyan-bright hover:underline"
+					>
+						{showAddProject ? 'Cancel' : '+ Add project'}
+					</button>
+				</div>
+
+				{showAddProject && (
+					<div className="mb-4">
+						<ProjectForm onDone={() => setShowAddProject(false)} />
+					</div>
+				)}
+
+				<div className="flex flex-col gap-2">
+					{projects.map((project) => (
+						<div
+							key={project.id}
+							className="flex items-center justify-between p-3 rounded-lg bg-white border"
+						>
+							<div>
+								<span className="font-medium">{project.name}</span>
+								{project.is_priority && (
+									<span className="ml-2 text-xs bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded">
+										priority
+									</span>
+								)}
+								{project.target_pct != null && (
+									<span className="ml-2 text-xs text-gray-400">
+										target: {project.target_pct}%
+									</span>
+								)}
+							</div>
+						</div>
+					))}
+					{projects.length === 0 && (
+						<p className="text-sm text-gray-400">No projects yet</p>
+					)}
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/app/(private)/flow/domains/project-form.tsx
+++ b/app/(private)/flow/domains/project-form.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { upsertProject } from '@/lib/flow'
+import { domainsQuery } from '../use-flow'
+import type { Project } from '@/types/flow'
+
+export default function ProjectForm({
+	existing,
+	onDone,
+}: {
+	existing?: Project
+	onDone?: () => void
+}) {
+	const [name, setName] = useState(existing?.name ?? '')
+	const [domainId, setDomainId] = useState<number | null>(
+		existing?.domain_id ?? null,
+	)
+	const [isPriority, setIsPriority] = useState(existing?.is_priority ?? false)
+	const [targetPct, setTargetPct] = useState(
+		existing?.target_pct?.toString() ?? '',
+	)
+	const { data: domains = [] } = useQuery(domainsQuery())
+	const queryClient = useQueryClient()
+
+	const save = useMutation({
+		mutationFn: () =>
+			upsertProject({
+				...(existing ? { id: existing.id } : {}),
+				name,
+				domain_id: domainId,
+				is_priority: isPriority,
+				target_pct: targetPct ? parseFloat(targetPct) : null,
+				description: null,
+				is_active: true,
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['flow', 'projects'] })
+			onDone?.()
+		},
+	})
+
+	return (
+		<div className="flex flex-col gap-3 p-4 bg-white rounded-xl border">
+			<input
+				type="text"
+				value={name}
+				onChange={(e) => setName(e.target.value)}
+				placeholder="Project name"
+				className="border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+			/>
+			<select
+				value={domainId ?? ''}
+				onChange={(e) =>
+					setDomainId(e.target.value ? Number(e.target.value) : null)
+				}
+				className="border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent text-sm"
+			>
+				<option value="">No domain</option>
+				{domains.map((d) => (
+					<option key={d.id} value={d.id}>
+						{d.icon} {d.name}
+					</option>
+				))}
+			</select>
+			<div className="flex items-center gap-4">
+				<label className="flex items-center gap-2 text-sm">
+					<input
+						type="checkbox"
+						checked={isPriority}
+						onChange={(e) => setIsPriority(e.target.checked)}
+					/>
+					Priority
+				</label>
+				{isPriority && (
+					<label className="flex items-center gap-1 text-sm">
+						Target:
+						<input
+							type="number"
+							value={targetPct}
+							onChange={(e) => setTargetPct(e.target.value)}
+							placeholder="%"
+							min="0"
+							max="100"
+							className="w-16 text-center border-b border-gray-300 focus:border-cyan focus:outline-none bg-transparent"
+						/>
+						%
+					</label>
+				)}
+			</div>
+			<button
+				onClick={() => save.mutate()}
+				disabled={save.isPending || !name}
+				className="self-end px-4 py-2 rounded bg-cyan text-white hover:bg-cyan-bright disabled:opacity-50 text-sm"
+			>
+				{save.isPending ? 'Saving...' : existing ? 'Update' : 'Add project'}
+			</button>
+		</div>
+	)
+}

--- a/app/(private)/flow/domains/project-form.tsx
+++ b/app/(private)/flow/domains/project-form.tsx
@@ -42,20 +42,20 @@ export default function ProjectForm({
 	})
 
 	return (
-		<div className="flex flex-col gap-3 p-4 bg-white rounded-xl border">
+		<div className="flow-card-interactive flex flex-col gap-3">
 			<input
 				type="text"
 				value={name}
 				onChange={(e) => setName(e.target.value)}
 				placeholder="Project name"
-				className="border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+				className="border border-flow-border rounded-lg px-2 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 			/>
 			<select
 				value={domainId ?? ''}
 				onChange={(e) =>
 					setDomainId(e.target.value ? Number(e.target.value) : null)
 				}
-				className="border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent text-sm"
+				className="border border-flow-border rounded-lg px-2 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none text-sm"
 			>
 				<option value="">No domain</option>
 				{domains.map((d) => (
@@ -83,7 +83,7 @@ export default function ProjectForm({
 							placeholder="%"
 							min="0"
 							max="100"
-							className="w-16 text-center border-b border-gray-300 focus:border-cyan focus:outline-none bg-transparent"
+							className="w-16 text-center border border-flow-border rounded-lg px-1 py-1 bg-flow-surface-alt focus:border-cyan focus:outline-none"
 						/>
 						%
 					</label>
@@ -92,7 +92,7 @@ export default function ProjectForm({
 			<button
 				onClick={() => save.mutate()}
 				disabled={save.isPending || !name}
-				className="self-end px-4 py-2 rounded bg-cyan text-white hover:bg-cyan-bright disabled:opacity-50 text-sm"
+				className="self-end px-4 py-2 rounded-lg bg-cyan text-white hover:bg-cyan-bright disabled:opacity-50 text-sm shadow-sm"
 			>
 				{save.isPending ? 'Saving...' : existing ? 'Update' : 'Add project'}
 			</button>

--- a/app/(private)/flow/flow-shell.tsx
+++ b/app/(private)/flow/flow-shell.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import TimerProvider from './timer/timer-provider'
+import MiniTimer from '@/components/flow/mini-timer'
+
+export default function FlowShell({ children }: { children: React.ReactNode }) {
+	useEffect(() => {
+		if ('serviceWorker' in navigator) {
+			navigator.serviceWorker.register('/flow-sw.js', { scope: '/flow' })
+		}
+	}, [])
+
+	return (
+		<TimerProvider>
+			<div className="min-h-screen bg-gray-50/50">
+				<header className="sticky top-0 z-20 bg-white/80 backdrop-blur-sm border-b px-4 py-2">
+					<div className="max-w-2xl mx-auto flex items-center justify-between">
+						<nav className="flex items-center gap-4 text-sm">
+							<Link
+								href="/flow"
+								className="font-display text-lg text-cyan-bright"
+							>
+								Flow
+							</Link>
+							<Link
+								href="/flow/check-in"
+								className="text-gray-500 hover:text-gray-700"
+							>
+								Check-in
+							</Link>
+							<Link
+								href="/flow/domains"
+								className="text-gray-500 hover:text-gray-700"
+							>
+								Domains
+							</Link>
+							<Link
+								href="/flow/history"
+								className="text-gray-500 hover:text-gray-700"
+							>
+								History
+							</Link>
+							<Link
+								href="/flow/settings"
+								className="text-gray-500 hover:text-gray-700"
+							>
+								Settings
+							</Link>
+						</nav>
+						<MiniTimer />
+					</div>
+				</header>
+				<main className="max-w-2xl mx-auto px-4 py-6">{children}</main>
+			</div>
+		</TimerProvider>
+	)
+}

--- a/app/(private)/flow/flow-shell.tsx
+++ b/app/(private)/flow/flow-shell.tsx
@@ -14,37 +14,37 @@ export default function FlowShell({ children }: { children: React.ReactNode }) {
 
 	return (
 		<TimerProvider>
-			<div className="min-h-screen bg-gray-50/50">
-				<header className="sticky top-0 z-20 bg-white/80 backdrop-blur-sm border-b px-4 py-2">
+			<div className="min-h-screen bg-flow-bg">
+				<header className="sticky top-0 z-20 bg-flow-surface/90 backdrop-blur-sm border-b border-flow-border shadow-sm px-4 py-2">
 					<div className="max-w-2xl mx-auto flex items-center justify-between">
 						<nav className="flex items-center gap-4 text-sm">
 							<Link
 								href="/flow"
-								className="font-display text-lg text-cyan-bright"
+								className="font-display text-lg font-bold text-cyan-bright"
 							>
 								Flow
 							</Link>
 							<Link
 								href="/flow/check-in"
-								className="text-gray-500 hover:text-gray-700"
+								className="text-flow-muted hover:text-gray-800"
 							>
 								Check-in
 							</Link>
 							<Link
 								href="/flow/domains"
-								className="text-gray-500 hover:text-gray-700"
+								className="text-flow-muted hover:text-gray-800"
 							>
 								Domains
 							</Link>
 							<Link
 								href="/flow/history"
-								className="text-gray-500 hover:text-gray-700"
+								className="text-flow-muted hover:text-gray-800"
 							>
 								History
 							</Link>
 							<Link
 								href="/flow/settings"
-								className="text-gray-500 hover:text-gray-700"
+								className="text-flow-muted hover:text-gray-800"
 							>
 								Settings
 							</Link>

--- a/app/(private)/flow/history/page.tsx
+++ b/app/(private)/flow/history/page.tsx
@@ -12,84 +12,93 @@ export default function HistoryPage() {
 		<div className="flex flex-col gap-6">
 			<h1 className="h2">History</h1>
 
-			<p className="text-gray-500 text-sm">
+			<p className="text-flow-muted text-sm">
 				Trend charts coming after 60+ days of data. For now, here&apos;s the raw
 				data.
 			</p>
 
 			{/* Recent check-ins */}
-			<section>
-				<h2 className="h4">Check-ins ({checkIns.length})</h2>
+			<section className="flow-card">
+				<h2 className="flow-section-heading mb-3">
+					Check-ins ({checkIns.length})
+				</h2>
 				<div className="overflow-x-auto">
 					<table className="w-full text-sm">
 						<thead>
-							<tr className="text-left text-gray-400 border-b">
-								<th className="py-1 pr-2">When</th>
-								<th className="py-1 px-1">Anx</th>
-								<th className="py-1 px-1">Dep</th>
-								<th className="py-1 px-1">Eng</th>
-								<th className="py-1 px-1">Ease</th>
-								<th className="py-1 px-1">Flow</th>
-								<th className="py-1 px-1">Focus</th>
+							<tr className="text-left text-flow-muted border-b border-flow-border">
+								<th className="py-1.5 pr-2 font-medium">When</th>
+								<th className="py-1.5 px-1 font-medium">Anx</th>
+								<th className="py-1.5 px-1 font-medium">Dep</th>
+								<th className="py-1.5 px-1 font-medium">Eng</th>
+								<th className="py-1.5 px-1 font-medium">Ease</th>
+								<th className="py-1.5 px-1 font-medium">Flow</th>
+								<th className="py-1.5 px-1 font-medium">Focus</th>
 							</tr>
 						</thead>
 						<tbody>
 							{checkIns.map((ci) => (
-								<tr key={ci.id} className="border-b border-gray-100">
-									<td className="py-1 pr-2 text-gray-400">
+								<tr
+									key={ci.id}
+									className="border-b border-flow-border/50"
+								>
+									<td className="py-1.5 pr-2 text-flow-muted">
 										{new Date(ci.created_at).toLocaleDateString([], {
 											month: 'short',
 											day: 'numeric',
 										})}
 									</td>
-									<td className="py-1 px-1">{ci.anxiety ?? '-'}</td>
-									<td className="py-1 px-1">{ci.depression ?? '-'}</td>
-									<td className="py-1 px-1">{ci.energy ?? '-'}</td>
-									<td className="py-1 px-1">{ci.ease ?? '-'}</td>
-									<td className="py-1 px-1">{ci.flow ?? '-'}</td>
-									<td className="py-1 px-1">{ci.focus ?? '-'}</td>
+									<td className="py-1.5 px-1">{ci.anxiety ?? '-'}</td>
+									<td className="py-1.5 px-1">{ci.depression ?? '-'}</td>
+									<td className="py-1.5 px-1">{ci.energy ?? '-'}</td>
+									<td className="py-1.5 px-1">{ci.ease ?? '-'}</td>
+									<td className="py-1.5 px-1">{ci.flow ?? '-'}</td>
+									<td className="py-1.5 px-1">{ci.focus ?? '-'}</td>
 								</tr>
 							))}
 						</tbody>
 					</table>
 				</div>
 				{checkIns.length === 0 && (
-					<p className="text-gray-400 text-sm mt-2">No check-ins yet</p>
+					<p className="text-flow-muted text-sm mt-2">No check-ins yet</p>
 				)}
 			</section>
 
 			{/* Recent sleep */}
-			<section>
-				<h2 className="h4">Sleep ({sleep.length} nights)</h2>
+			<section className="flow-card">
+				<h2 className="flow-section-heading mb-3">
+					Sleep ({sleep.length} nights)
+				</h2>
 				<div className="flex flex-col gap-1">
 					{sleep.map((s) => (
 						<div
 							key={s.id}
-							className="flex items-center gap-3 text-sm py-1 border-b border-gray-100"
+							className="flex items-center gap-3 text-sm py-1.5 border-b border-flow-border/50"
 						>
-							<span className="text-gray-400 w-20">{s.date}</span>
+							<span className="text-flow-muted w-20">{s.date}</span>
 							<span>{s.hours_slept != null ? `${s.hours_slept}h` : '-'}</span>
-							<span className="text-gray-400">
+							<span className="text-flow-muted">
 								quality: {s.quality ?? '-'}/5
 							</span>
 						</div>
 					))}
 				</div>
 				{sleep.length === 0 && (
-					<p className="text-gray-400 text-sm mt-2">No sleep data yet</p>
+					<p className="text-flow-muted text-sm mt-2">No sleep data yet</p>
 				)}
 			</section>
 
 			{/* Recent sessions */}
-			<section>
-				<h2 className="h4">Sessions ({sessions.length})</h2>
+			<section className="flow-card">
+				<h2 className="flow-section-heading mb-3">
+					Sessions ({sessions.length})
+				</h2>
 				<div className="flex flex-col gap-1">
 					{sessions.map((s) => (
 						<div
 							key={s.id}
-							className="flex items-center gap-3 text-sm py-1 border-b border-gray-100"
+							className="flex items-center gap-3 text-sm py-1.5 border-b border-flow-border/50"
 						>
-							<span className="text-gray-400 w-20">
+							<span className="text-flow-muted w-20">
 								{new Date(s.started_at).toLocaleDateString([], {
 									month: 'short',
 									day: 'numeric',
@@ -98,12 +107,14 @@ export default function HistoryPage() {
 							<span className="flex-1 truncate">
 								{s.intention || 'Untitled'}
 							</span>
-							<span className="text-gray-400">
+							<span className="text-flow-muted">
 								{Math.round(s.duration_seconds / 60)}m
 							</span>
 							<span
 								className={`text-xs ${
-									s.status === 'completed' ? 'text-green-600' : 'text-gray-400'
+									s.status === 'completed'
+										? 'text-green-600'
+										: 'text-flow-muted'
 								}`}
 							>
 								{s.status}
@@ -112,7 +123,7 @@ export default function HistoryPage() {
 					))}
 				</div>
 				{sessions.length === 0 && (
-					<p className="text-gray-400 text-sm mt-2">No sessions yet</p>
+					<p className="text-flow-muted text-sm mt-2">No sessions yet</p>
 				)}
 			</section>
 		</div>

--- a/app/(private)/flow/history/page.tsx
+++ b/app/(private)/flow/history/page.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { checkInsQuery, sessionsQuery, recentSleepQuery } from '../use-flow'
+
+export default function HistoryPage() {
+	const { data: checkIns = [] } = useQuery(checkInsQuery(30))
+	const { data: sessions = [] } = useQuery(sessionsQuery(50))
+	const { data: sleep = [] } = useQuery(recentSleepQuery(14))
+
+	return (
+		<div className="flex flex-col gap-6">
+			<h1 className="h2">History</h1>
+
+			<p className="text-gray-500 text-sm">
+				Trend charts coming after 60+ days of data. For now, here&apos;s the raw
+				data.
+			</p>
+
+			{/* Recent check-ins */}
+			<section>
+				<h2 className="h4">Check-ins ({checkIns.length})</h2>
+				<div className="overflow-x-auto">
+					<table className="w-full text-sm">
+						<thead>
+							<tr className="text-left text-gray-400 border-b">
+								<th className="py-1 pr-2">When</th>
+								<th className="py-1 px-1">Anx</th>
+								<th className="py-1 px-1">Dep</th>
+								<th className="py-1 px-1">Eng</th>
+								<th className="py-1 px-1">Ease</th>
+								<th className="py-1 px-1">Flow</th>
+								<th className="py-1 px-1">Focus</th>
+							</tr>
+						</thead>
+						<tbody>
+							{checkIns.map((ci) => (
+								<tr key={ci.id} className="border-b border-gray-100">
+									<td className="py-1 pr-2 text-gray-400">
+										{new Date(ci.created_at).toLocaleDateString([], {
+											month: 'short',
+											day: 'numeric',
+										})}
+									</td>
+									<td className="py-1 px-1">{ci.anxiety ?? '-'}</td>
+									<td className="py-1 px-1">{ci.depression ?? '-'}</td>
+									<td className="py-1 px-1">{ci.energy ?? '-'}</td>
+									<td className="py-1 px-1">{ci.ease ?? '-'}</td>
+									<td className="py-1 px-1">{ci.flow ?? '-'}</td>
+									<td className="py-1 px-1">{ci.focus ?? '-'}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+				{checkIns.length === 0 && (
+					<p className="text-gray-400 text-sm mt-2">No check-ins yet</p>
+				)}
+			</section>
+
+			{/* Recent sleep */}
+			<section>
+				<h2 className="h4">Sleep ({sleep.length} nights)</h2>
+				<div className="flex flex-col gap-1">
+					{sleep.map((s) => (
+						<div
+							key={s.id}
+							className="flex items-center gap-3 text-sm py-1 border-b border-gray-100"
+						>
+							<span className="text-gray-400 w-20">{s.date}</span>
+							<span>{s.hours_slept != null ? `${s.hours_slept}h` : '-'}</span>
+							<span className="text-gray-400">
+								quality: {s.quality ?? '-'}/5
+							</span>
+						</div>
+					))}
+				</div>
+				{sleep.length === 0 && (
+					<p className="text-gray-400 text-sm mt-2">No sleep data yet</p>
+				)}
+			</section>
+
+			{/* Recent sessions */}
+			<section>
+				<h2 className="h4">Sessions ({sessions.length})</h2>
+				<div className="flex flex-col gap-1">
+					{sessions.map((s) => (
+						<div
+							key={s.id}
+							className="flex items-center gap-3 text-sm py-1 border-b border-gray-100"
+						>
+							<span className="text-gray-400 w-20">
+								{new Date(s.started_at).toLocaleDateString([], {
+									month: 'short',
+									day: 'numeric',
+								})}
+							</span>
+							<span className="flex-1 truncate">
+								{s.intention || 'Untitled'}
+							</span>
+							<span className="text-gray-400">
+								{Math.round(s.duration_seconds / 60)}m
+							</span>
+							<span
+								className={`text-xs ${
+									s.status === 'completed' ? 'text-green-600' : 'text-gray-400'
+								}`}
+							>
+								{s.status}
+							</span>
+						</div>
+					))}
+				</div>
+				{sessions.length === 0 && (
+					<p className="text-gray-400 text-sm mt-2">No sessions yet</p>
+				)}
+			</section>
+		</div>
+	)
+}

--- a/app/(private)/flow/layout.tsx
+++ b/app/(private)/flow/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata, Viewport } from 'next'
+import FlowShell from './flow-shell'
+
+export const metadata: Metadata = {
+	title: 'Flow',
+	description: 'Personal activity & wellbeing tracker',
+	manifest: '/flow-manifest.json',
+	appleWebApp: {
+		capable: true,
+		statusBarStyle: 'default',
+		title: 'Flow',
+	},
+}
+
+export const viewport: Viewport = {
+	themeColor: '#0087c1',
+}
+
+export default function FlowLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return <FlowShell>{children}</FlowShell>
+}

--- a/app/(private)/flow/page.tsx
+++ b/app/(private)/flow/page.tsx
@@ -1,0 +1,5 @@
+import Dashboard from './dashboard'
+
+export default function FlowPage() {
+	return <Dashboard />
+}

--- a/app/(private)/flow/settings/page.tsx
+++ b/app/(private)/flow/settings/page.tsx
@@ -48,18 +48,18 @@ function HabitManager() {
 	})
 
 	return (
-		<section className="flex flex-col gap-3">
-			<h2 className="h3">Habits</h2>
+		<section className="flow-card flex flex-col gap-3">
+			<h2 className="flow-section-heading">Habits</h2>
 			<div className="flex flex-col gap-1">
 				{habits.map((h) => (
 					<div
 						key={h.id}
-						className="flex items-center justify-between py-2 px-3 bg-white rounded border"
+						className="flex items-center justify-between py-2 px-3 bg-flow-surface-alt rounded-lg border border-flow-border/50"
 					>
 						<span>
 							{h.icon && <span className="mr-2">{h.icon}</span>}
 							{h.name}
-							<span className="text-xs text-gray-400 ml-2">{h.category}</span>
+							<span className="text-xs text-flow-muted ml-2">{h.category}</span>
 						</span>
 						<button
 							onClick={() =>
@@ -68,27 +68,27 @@ function HabitManager() {
 									is_active: !h.is_active,
 								})
 							}
-							className="text-xs text-gray-400 hover:text-red-500"
+							className="text-xs text-flow-muted hover:text-red-500"
 						>
 							{h.is_active ? 'Disable' : 'Enable'}
 						</button>
 					</div>
 				))}
 			</div>
-			<div className="flex gap-2 items-end">
+			<div className="flex gap-2 items-end pt-2 border-t border-flow-border/50">
 				<input
 					type="text"
 					value={newIcon}
 					onChange={(e) => setNewIcon(e.target.value)}
 					placeholder="Icon"
-					className="w-12 text-center border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+					className="w-12 text-center border border-flow-border rounded-lg px-1 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 				/>
 				<input
 					type="text"
 					value={newName}
 					onChange={(e) => setNewName(e.target.value)}
 					placeholder="New habit name"
-					className="flex-1 border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+					className="flex-1 border border-flow-border rounded-lg px-2 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 					onKeyDown={(e) => {
 						if (e.key === 'Enter' && newName) addHabit.mutate()
 					}}
@@ -96,7 +96,7 @@ function HabitManager() {
 				<select
 					value={newCategory}
 					onChange={(e) => setNewCategory(e.target.value as HabitCategory)}
-					className="text-sm border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+					className="text-sm border border-flow-border rounded-lg px-2 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 				>
 					<option value="positive">positive</option>
 					<option value="neutral">neutral</option>
@@ -104,7 +104,7 @@ function HabitManager() {
 				<button
 					onClick={() => addHabit.mutate()}
 					disabled={!newName || addHabit.isPending}
-					className="px-3 py-1 rounded bg-cyan text-white text-sm hover:bg-cyan-bright disabled:opacity-50"
+					className="px-3 py-1.5 rounded-lg bg-cyan text-white text-sm hover:bg-cyan-bright disabled:opacity-50 shadow-sm"
 				>
 					Add
 				</button>
@@ -138,33 +138,33 @@ function DomainManager() {
 	})
 
 	return (
-		<section className="flex flex-col gap-3">
-			<h2 className="h3">Domains</h2>
+		<section className="flow-card flex flex-col gap-3">
+			<h2 className="flow-section-heading">Domains</h2>
 			<div className="flex flex-col gap-1">
 				{domains.map((d) => (
 					<div
 						key={d.id}
-						className="flex items-center gap-2 py-2 px-3 bg-white rounded border"
+						className="flex items-center gap-2 py-2 px-3 bg-flow-surface-alt rounded-lg border border-flow-border/50"
 					>
 						{d.icon && <span>{d.icon}</span>}
 						<span>{d.name}</span>
 					</div>
 				))}
 			</div>
-			<div className="flex gap-2 items-end">
+			<div className="flex gap-2 items-end pt-2 border-t border-flow-border/50">
 				<input
 					type="text"
 					value={newIcon}
 					onChange={(e) => setNewIcon(e.target.value)}
 					placeholder="Icon"
-					className="w-12 text-center border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+					className="w-12 text-center border border-flow-border rounded-lg px-1 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 				/>
 				<input
 					type="text"
 					value={newName}
 					onChange={(e) => setNewName(e.target.value)}
 					placeholder="New domain name"
-					className="flex-1 border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+					className="flex-1 border border-flow-border rounded-lg px-2 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 					onKeyDown={(e) => {
 						if (e.key === 'Enter' && newName) addDomain.mutate()
 					}}
@@ -172,7 +172,7 @@ function DomainManager() {
 				<button
 					onClick={() => addDomain.mutate()}
 					disabled={!newName || addDomain.isPending}
-					className="px-3 py-1 rounded bg-cyan text-white text-sm hover:bg-cyan-bright disabled:opacity-50"
+					className="px-3 py-1.5 rounded-lg bg-cyan text-white text-sm hover:bg-cyan-bright disabled:opacity-50 shadow-sm"
 				>
 					Add
 				</button>
@@ -183,18 +183,18 @@ function DomainManager() {
 
 function ApiStatus() {
 	return (
-		<section className="flex flex-col gap-3">
-			<h2 className="h3">Integrations</h2>
+		<section className="flow-card flex flex-col gap-3">
+			<h2 className="flow-section-heading">Integrations</h2>
 			<div className="flex flex-col gap-2">
-				<div className="flex items-center justify-between py-2 px-3 bg-white rounded border">
+				<div className="flex items-center justify-between py-2 px-3 bg-flow-surface-alt rounded-lg border border-flow-border/50">
 					<span>Todoist</span>
-					<span className="text-xs text-gray-400">
+					<span className="text-xs text-flow-muted">
 						Configure TODOIST_API_TOKEN in env
 					</span>
 				</div>
-				<div className="flex items-center justify-between py-2 px-3 bg-white rounded border">
+				<div className="flex items-center justify-between py-2 px-3 bg-flow-surface-alt rounded-lg border border-flow-border/50">
 					<span>GitHub</span>
-					<span className="text-xs text-gray-400">
+					<span className="text-xs text-flow-muted">
 						Configure GITHUB_TOKEN in env
 					</span>
 				</div>

--- a/app/(private)/flow/settings/page.tsx
+++ b/app/(private)/flow/settings/page.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { habitDefinitionsQuery, domainsQuery } from '../use-flow'
+import { upsertHabitDefinition, upsertDomain } from '@/lib/flow'
+import type { HabitCategory } from '@/types/flow'
+
+function HabitManager() {
+	const { data: habits = [] } = useQuery(habitDefinitionsQuery())
+	const queryClient = useQueryClient()
+	const [newName, setNewName] = useState('')
+	const [newIcon, setNewIcon] = useState('')
+	const [newCategory, setNewCategory] = useState<HabitCategory>('positive')
+
+	const addHabit = useMutation({
+		mutationFn: () =>
+			upsertHabitDefinition({
+				name: newName,
+				icon: newIcon || null,
+				category: newCategory,
+				domain_id: null,
+				sort_order: habits.length,
+				is_active: true,
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['flow', 'habit-definitions'] })
+			setNewName('')
+			setNewIcon('')
+		},
+	})
+
+	const toggleActive = useMutation({
+		mutationFn: ({ id, is_active }: { id: number; is_active: boolean }) =>
+			upsertHabitDefinition({
+				id,
+				name: habits.find((h) => h.id === id)!.name,
+				icon: habits.find((h) => h.id === id)!.icon,
+				category: habits.find((h) => h.id === id)!.category,
+				domain_id: habits.find((h) => h.id === id)!.domain_id,
+				sort_order: habits.find((h) => h.id === id)!.sort_order,
+				is_active,
+			}),
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: ['flow', 'habit-definitions'],
+			}),
+	})
+
+	return (
+		<section className="flex flex-col gap-3">
+			<h2 className="h3">Habits</h2>
+			<div className="flex flex-col gap-1">
+				{habits.map((h) => (
+					<div
+						key={h.id}
+						className="flex items-center justify-between py-2 px-3 bg-white rounded border"
+					>
+						<span>
+							{h.icon && <span className="mr-2">{h.icon}</span>}
+							{h.name}
+							<span className="text-xs text-gray-400 ml-2">{h.category}</span>
+						</span>
+						<button
+							onClick={() =>
+								toggleActive.mutate({
+									id: h.id,
+									is_active: !h.is_active,
+								})
+							}
+							className="text-xs text-gray-400 hover:text-red-500"
+						>
+							{h.is_active ? 'Disable' : 'Enable'}
+						</button>
+					</div>
+				))}
+			</div>
+			<div className="flex gap-2 items-end">
+				<input
+					type="text"
+					value={newIcon}
+					onChange={(e) => setNewIcon(e.target.value)}
+					placeholder="Icon"
+					className="w-12 text-center border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+				/>
+				<input
+					type="text"
+					value={newName}
+					onChange={(e) => setNewName(e.target.value)}
+					placeholder="New habit name"
+					className="flex-1 border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' && newName) addHabit.mutate()
+					}}
+				/>
+				<select
+					value={newCategory}
+					onChange={(e) => setNewCategory(e.target.value as HabitCategory)}
+					className="text-sm border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+				>
+					<option value="positive">positive</option>
+					<option value="neutral">neutral</option>
+				</select>
+				<button
+					onClick={() => addHabit.mutate()}
+					disabled={!newName || addHabit.isPending}
+					className="px-3 py-1 rounded bg-cyan text-white text-sm hover:bg-cyan-bright disabled:opacity-50"
+				>
+					Add
+				</button>
+			</div>
+		</section>
+	)
+}
+
+function DomainManager() {
+	const { data: domains = [] } = useQuery(domainsQuery())
+	const queryClient = useQueryClient()
+	const [newName, setNewName] = useState('')
+	const [newIcon, setNewIcon] = useState('')
+	const [newColor, setNewColor] = useState('')
+
+	const addDomain = useMutation({
+		mutationFn: () =>
+			upsertDomain({
+				name: newName,
+				icon: newIcon || null,
+				color: newColor || null,
+				sort_order: domains.length,
+				is_active: true,
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['flow', 'domains'] })
+			setNewName('')
+			setNewIcon('')
+			setNewColor('')
+		},
+	})
+
+	return (
+		<section className="flex flex-col gap-3">
+			<h2 className="h3">Domains</h2>
+			<div className="flex flex-col gap-1">
+				{domains.map((d) => (
+					<div
+						key={d.id}
+						className="flex items-center gap-2 py-2 px-3 bg-white rounded border"
+					>
+						{d.icon && <span>{d.icon}</span>}
+						<span>{d.name}</span>
+					</div>
+				))}
+			</div>
+			<div className="flex gap-2 items-end">
+				<input
+					type="text"
+					value={newIcon}
+					onChange={(e) => setNewIcon(e.target.value)}
+					placeholder="Icon"
+					className="w-12 text-center border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+				/>
+				<input
+					type="text"
+					value={newName}
+					onChange={(e) => setNewName(e.target.value)}
+					placeholder="New domain name"
+					className="flex-1 border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent"
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' && newName) addDomain.mutate()
+					}}
+				/>
+				<button
+					onClick={() => addDomain.mutate()}
+					disabled={!newName || addDomain.isPending}
+					className="px-3 py-1 rounded bg-cyan text-white text-sm hover:bg-cyan-bright disabled:opacity-50"
+				>
+					Add
+				</button>
+			</div>
+		</section>
+	)
+}
+
+function ApiStatus() {
+	return (
+		<section className="flex flex-col gap-3">
+			<h2 className="h3">Integrations</h2>
+			<div className="flex flex-col gap-2">
+				<div className="flex items-center justify-between py-2 px-3 bg-white rounded border">
+					<span>Todoist</span>
+					<span className="text-xs text-gray-400">
+						Configure TODOIST_API_TOKEN in env
+					</span>
+				</div>
+				<div className="flex items-center justify-between py-2 px-3 bg-white rounded border">
+					<span>GitHub</span>
+					<span className="text-xs text-gray-400">
+						Configure GITHUB_TOKEN in env
+					</span>
+				</div>
+			</div>
+		</section>
+	)
+}
+
+export default function SettingsPage() {
+	return (
+		<div className="flex flex-col gap-8">
+			<h1 className="h2">Settings</h1>
+			<HabitManager />
+			<DomainManager />
+			<ApiStatus />
+		</div>
+	)
+}

--- a/app/(private)/flow/timer/intention-form.tsx
+++ b/app/(private)/flow/timer/intention-form.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState } from 'react'
+import { useTimerStore } from './timer-store'
+import { createSession } from '@/lib/flow'
+import { useQueryClient } from '@tanstack/react-query'
+
+const DURATION_OPTIONS = [
+	{ label: '15m', seconds: 900 },
+	{ label: '25m', seconds: 1500 },
+	{ label: '50m', seconds: 3000 },
+]
+
+export default function IntentionForm() {
+	const [intention, setIntention] = useState('')
+	const [duration, setDuration] = useState(1500)
+	const [isStarting, setIsStarting] = useState(false)
+	const startTimer = useTimerStore((s) => s.startTimer)
+	const status = useTimerStore((s) => s.status)
+	const queryClient = useQueryClient()
+
+	if (status !== 'idle') return null
+
+	const handleStart = async () => {
+		setIsStarting(true)
+		try {
+			const session = await createSession({
+				duration_seconds: duration,
+				intention: intention || null,
+				status: 'running',
+				started_at: new Date().toISOString(),
+			})
+			startTimer(duration, intention, session.id)
+			queryClient.invalidateQueries({ queryKey: ['flow', 'sessions'] })
+			setIntention('')
+		} finally {
+			setIsStarting(false)
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-4">
+			<input
+				type="text"
+				value={intention}
+				onChange={(e) => setIntention(e.target.value)}
+				placeholder="What are you working on?"
+				className="text-center text-lg border-b border-gray-300 focus:border-cyan focus:outline-none py-2 bg-transparent"
+				onKeyDown={(e) => {
+					if (e.key === 'Enter') handleStart()
+				}}
+			/>
+
+			<div className="flex gap-2 justify-center">
+				{DURATION_OPTIONS.map((opt) => (
+					<button
+						key={opt.seconds}
+						onClick={() => setDuration(opt.seconds)}
+						className={`px-4 py-2 rounded-lg text-sm ${
+							duration === opt.seconds
+								? 'bg-cyan text-white'
+								: 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+						}`}
+					>
+						{opt.label}
+					</button>
+				))}
+			</div>
+
+			<button
+				onClick={handleStart}
+				disabled={isStarting}
+				className="px-8 py-4 rounded-xl bg-cyan-bright text-white text-xl hover:bg-cyan disabled:opacity-50 mx-auto"
+			>
+				{isStarting ? 'Starting...' : 'Start'}
+			</button>
+		</div>
+	)
+}

--- a/app/(private)/flow/timer/intention-form.tsx
+++ b/app/(private)/flow/timer/intention-form.tsx
@@ -45,7 +45,7 @@ export default function IntentionForm() {
 				value={intention}
 				onChange={(e) => setIntention(e.target.value)}
 				placeholder="What are you working on?"
-				className="text-center text-lg border-b border-gray-300 focus:border-cyan focus:outline-none py-2 bg-transparent"
+				className="text-center text-lg border border-flow-border rounded-lg px-3 py-2.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none"
 				onKeyDown={(e) => {
 					if (e.key === 'Enter') handleStart()
 				}}
@@ -58,8 +58,8 @@ export default function IntentionForm() {
 						onClick={() => setDuration(opt.seconds)}
 						className={`px-4 py-2 rounded-lg text-sm ${
 							duration === opt.seconds
-								? 'bg-cyan text-white'
-								: 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+								? 'bg-cyan text-white shadow-sm'
+								: 'bg-flow-surface-alt border border-flow-border text-flow-muted hover:bg-flow-bg'
 						}`}
 					>
 						{opt.label}
@@ -70,7 +70,7 @@ export default function IntentionForm() {
 			<button
 				onClick={handleStart}
 				disabled={isStarting}
-				className="px-8 py-4 rounded-xl bg-cyan-bright text-white text-xl hover:bg-cyan disabled:opacity-50 mx-auto"
+				className="px-8 py-4 rounded-xl bg-cyan-bright text-white text-xl font-display font-bold hover:bg-cyan disabled:opacity-50 mx-auto shadow-sm"
 			>
 				{isStarting ? 'Starting...' : 'Start'}
 			</button>

--- a/app/(private)/flow/timer/session-complete.tsx
+++ b/app/(private)/flow/timer/session-complete.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import { useTimerStore } from './timer-store'
+import { updateSession } from '@/lib/flow'
+import { useQueryClient } from '@tanstack/react-query'
+import ScaleInput from '@/components/flow/scale-input'
+
+export default function SessionComplete({ onDone }: { onDone: () => void }) {
+	const sessionId = useTimerStore((s) => s.sessionId)
+	const startBreak = useTimerStore((s) => s.startBreak)
+	const stopTimer = useTimerStore((s) => s.stopTimer)
+	const [mood, setMood] = useState<number | null>(null)
+	const [energy, setEnergy] = useState<number | null>(null)
+	const [saving, setSaving] = useState(false)
+	const queryClient = useQueryClient()
+
+	const handleSave = async () => {
+		setSaving(true)
+		try {
+			if (sessionId) {
+				await updateSession(sessionId, {
+					status: 'completed',
+					ended_at: new Date().toISOString(),
+					mood,
+					energy,
+				})
+				queryClient.invalidateQueries({ queryKey: ['flow', 'sessions'] })
+			}
+		} finally {
+			setSaving(false)
+			onDone()
+		}
+	}
+
+	const handleSkip = async () => {
+		if (sessionId) {
+			await updateSession(sessionId, {
+				status: 'completed',
+				ended_at: new Date().toISOString(),
+			})
+			queryClient.invalidateQueries({ queryKey: ['flow', 'sessions'] })
+		}
+		onDone()
+	}
+
+	const handleBreak = async () => {
+		await handleSave()
+		startBreak(300)
+	}
+
+	return (
+		<div className="flex flex-col items-center gap-6 py-4">
+			<p className="text-2xl font-display">Session complete</p>
+
+			<div className="flex flex-col gap-4 w-full max-w-xs">
+				<div>
+					<label className="text-sm text-gray-500 mb-1 block">Mood</label>
+					<ScaleInput value={mood} onChange={setMood} />
+				</div>
+				<div>
+					<label className="text-sm text-gray-500 mb-1 block">Energy</label>
+					<ScaleInput value={energy} onChange={setEnergy} />
+				</div>
+			</div>
+
+			<div className="flex gap-3 flex-wrap justify-center">
+				<button
+					onClick={handleBreak}
+					disabled={saving}
+					className="px-5 py-3 rounded-lg bg-green-100 text-green-700 hover:bg-green-200"
+				>
+					Take a break (5m)
+				</button>
+				<button
+					onClick={handleSave}
+					disabled={saving}
+					className="px-5 py-3 rounded-lg bg-cyan text-white hover:bg-cyan-bright"
+				>
+					Done
+				</button>
+				<button
+					onClick={handleSkip}
+					className="px-5 py-3 rounded-lg text-gray-400 hover:text-gray-600"
+				>
+					Skip
+				</button>
+			</div>
+		</div>
+	)
+}

--- a/app/(private)/flow/timer/session-complete.tsx
+++ b/app/(private)/flow/timer/session-complete.tsx
@@ -50,16 +50,18 @@ export default function SessionComplete({ onDone }: { onDone: () => void }) {
 	}
 
 	return (
-		<div className="flex flex-col items-center gap-6 py-4">
-			<p className="text-2xl font-display">Session complete</p>
+		<div className="flex flex-col items-center gap-6 py-4 w-full">
+			<p className="text-2xl font-display font-bold text-flow-heading">
+				Session complete
+			</p>
 
 			<div className="flex flex-col gap-4 w-full max-w-xs">
 				<div>
-					<label className="text-sm text-gray-500 mb-1 block">Mood</label>
+					<label className="flow-section-heading mb-1 block">Mood</label>
 					<ScaleInput value={mood} onChange={setMood} />
 				</div>
 				<div>
-					<label className="text-sm text-gray-500 mb-1 block">Energy</label>
+					<label className="flow-section-heading mb-1 block">Energy</label>
 					<ScaleInput value={energy} onChange={setEnergy} />
 				</div>
 			</div>
@@ -68,20 +70,20 @@ export default function SessionComplete({ onDone }: { onDone: () => void }) {
 				<button
 					onClick={handleBreak}
 					disabled={saving}
-					className="px-5 py-3 rounded-lg bg-green-100 text-green-700 hover:bg-green-200"
+					className="px-5 py-3 rounded-lg bg-green-100 border border-green-200 text-green-700 hover:bg-green-200"
 				>
 					Take a break (5m)
 				</button>
 				<button
 					onClick={handleSave}
 					disabled={saving}
-					className="px-5 py-3 rounded-lg bg-cyan text-white hover:bg-cyan-bright"
+					className="px-5 py-3 rounded-lg bg-cyan text-white hover:bg-cyan-bright shadow-sm"
 				>
 					Done
 				</button>
 				<button
 					onClick={handleSkip}
-					className="px-5 py-3 rounded-lg text-gray-400 hover:text-gray-600"
+					className="px-5 py-3 rounded-lg text-flow-muted hover:text-gray-600"
 				>
 					Skip
 				</button>

--- a/app/(private)/flow/timer/timer-controls.tsx
+++ b/app/(private)/flow/timer/timer-controls.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useTimerStore } from './timer-store'
+import { updateSession } from '@/lib/flow'
+import { useQueryClient } from '@tanstack/react-query'
+
+export default function TimerControls({
+	onComplete,
+}: {
+	onComplete?: () => void
+}) {
+	const status = useTimerStore((s) => s.status)
+	const sessionId = useTimerStore((s) => s.sessionId)
+	const pauseTimer = useTimerStore((s) => s.pauseTimer)
+	const resumeTimer = useTimerStore((s) => s.resumeTimer)
+	const stopTimer = useTimerStore((s) => s.stopTimer)
+	const queryClient = useQueryClient()
+
+	if (status === 'idle') return null
+
+	const handlePause = () => {
+		if (status === 'running') pauseTimer()
+		else if (status === 'paused') resumeTimer()
+	}
+
+	const handleStop = async () => {
+		if (sessionId) {
+			await updateSession(sessionId, {
+				status: 'abandoned',
+				ended_at: new Date().toISOString(),
+			})
+			queryClient.invalidateQueries({ queryKey: ['flow', 'sessions'] })
+		}
+		stopTimer()
+	}
+
+	const handleBreakEnd = () => {
+		stopTimer()
+	}
+
+	const isBreak = status === 'break'
+
+	if (isBreak) {
+		return (
+			<div className="flex gap-3 justify-center">
+				<button
+					onClick={handleBreakEnd}
+					className="px-6 py-3 rounded-lg bg-gray-200 text-gray-700 hover:bg-gray-300 text-lg"
+				>
+					End break
+				</button>
+			</div>
+		)
+	}
+
+	return (
+		<div className="flex gap-3 justify-center">
+			<button
+				onClick={handlePause}
+				className="px-6 py-3 rounded-lg bg-gray-200 text-gray-700 hover:bg-gray-300 text-lg"
+			>
+				{status === 'paused' ? 'Resume' : 'Pause'}
+			</button>
+			<button
+				onClick={handleStop}
+				className="px-6 py-3 rounded-lg bg-red-100 text-red-700 hover:bg-red-200 text-lg"
+			>
+				Stop
+			</button>
+		</div>
+	)
+}

--- a/app/(private)/flow/timer/timer-controls.tsx
+++ b/app/(private)/flow/timer/timer-controls.tsx
@@ -45,7 +45,7 @@ export default function TimerControls({
 			<div className="flex gap-3 justify-center">
 				<button
 					onClick={handleBreakEnd}
-					className="px-6 py-3 rounded-lg bg-gray-200 text-gray-700 hover:bg-gray-300 text-lg"
+					className="px-6 py-3 rounded-lg bg-flow-surface-alt border border-flow-border text-gray-700 hover:bg-flow-bg text-lg"
 				>
 					End break
 				</button>
@@ -57,7 +57,7 @@ export default function TimerControls({
 		<div className="flex gap-3 justify-center">
 			<button
 				onClick={handlePause}
-				className="px-6 py-3 rounded-lg bg-gray-200 text-gray-700 hover:bg-gray-300 text-lg"
+				className="px-6 py-3 rounded-lg bg-flow-surface-alt border border-flow-border text-gray-700 hover:bg-flow-bg text-lg"
 			>
 				{status === 'paused' ? 'Resume' : 'Pause'}
 			</button>

--- a/app/(private)/flow/timer/timer-display.tsx
+++ b/app/(private)/flow/timer/timer-display.tsx
@@ -31,7 +31,7 @@ export default function TimerDisplay() {
 			</div>
 
 			{/* Progress bar */}
-			<div className="w-full max-w-xs h-2 bg-gray-200 rounded-full overflow-hidden">
+			<div className="w-full max-w-xs h-2 bg-flow-border rounded-full overflow-hidden">
 				<div
 					className={`h-full rounded-full transition-all duration-1000 ${
 						isBreak ? 'bg-green-400' : 'bg-cyan'
@@ -41,11 +41,11 @@ export default function TimerDisplay() {
 			</div>
 
 			{intention && (
-				<p className="text-gray-500 text-sm">{isBreak ? 'Break' : intention}</p>
+				<p className="text-flow-muted text-sm">{isBreak ? 'Break' : intention}</p>
 			)}
 
 			{status === 'paused' && (
-				<p className="text-gray-400 text-xs uppercase tracking-wide">Paused</p>
+				<p className="text-flow-muted text-xs uppercase tracking-wide">Paused</p>
 			)}
 		</div>
 	)

--- a/app/(private)/flow/timer/timer-display.tsx
+++ b/app/(private)/flow/timer/timer-display.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useTimerStore } from './timer-store'
+
+function formatTime(seconds: number) {
+	const m = Math.floor(seconds / 60)
+	const s = seconds % 60
+	return `${m}:${String(s).padStart(2, '0')}`
+}
+
+export default function TimerDisplay() {
+	const status = useTimerStore((s) => s.status)
+	const secondsRemaining = useTimerStore((s) => s.secondsRemaining)
+	const durationSeconds = useTimerStore((s) => s.durationSeconds)
+	const intention = useTimerStore((s) => s.intention)
+
+	if (status === 'idle') return null
+
+	const progress =
+		durationSeconds > 0 ? 1 - secondsRemaining / durationSeconds : 0
+	const isBreak = status === 'break'
+
+	return (
+		<div className="flex flex-col items-center gap-3">
+			<div
+				className={`font-display text-7xl sm:text-8xl tabular-nums tracking-tight ${
+					status === 'paused' ? 'opacity-50' : ''
+				} ${isBreak ? 'text-green-600' : 'text-cyan-bright'}`}
+			>
+				{formatTime(secondsRemaining)}
+			</div>
+
+			{/* Progress bar */}
+			<div className="w-full max-w-xs h-2 bg-gray-200 rounded-full overflow-hidden">
+				<div
+					className={`h-full rounded-full transition-all duration-1000 ${
+						isBreak ? 'bg-green-400' : 'bg-cyan'
+					}`}
+					style={{ width: `${progress * 100}%` }}
+				/>
+			</div>
+
+			{intention && (
+				<p className="text-gray-500 text-sm">{isBreak ? 'Break' : intention}</p>
+			)}
+
+			{status === 'paused' && (
+				<p className="text-gray-400 text-xs uppercase tracking-wide">Paused</p>
+			)}
+		</div>
+	)
+}

--- a/app/(private)/flow/timer/timer-provider.tsx
+++ b/app/(private)/flow/timer/timer-provider.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useTimerStore } from './timer-store'
+
+export default function TimerProvider({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	const status = useTimerStore((s) => s.status)
+	const secondsRemaining = useTimerStore((s) => s.secondsRemaining)
+	const tick = useTimerStore((s) => s.tick)
+	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+	useEffect(() => {
+		if (status === 'running' || status === 'break') {
+			intervalRef.current = setInterval(() => {
+				tick()
+			}, 1000)
+		} else {
+			if (intervalRef.current) {
+				clearInterval(intervalRef.current)
+				intervalRef.current = null
+			}
+		}
+		return () => {
+			if (intervalRef.current) clearInterval(intervalRef.current)
+		}
+	}, [status, tick])
+
+	// Update page title with timer
+	useEffect(() => {
+		if (status === 'running' || status === 'paused' || status === 'break') {
+			const m = Math.floor(secondsRemaining / 60)
+			const s = secondsRemaining % 60
+			document.title = `${m}:${String(s).padStart(2, '0')} — Flow`
+		} else {
+			document.title = 'Flow — msnook.xyz'
+		}
+	}, [status, secondsRemaining])
+
+	return <>{children}</>
+}

--- a/app/(private)/flow/timer/timer-store.ts
+++ b/app/(private)/flow/timer/timer-store.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand'
+
+export type TimerStatus = 'idle' | 'running' | 'paused' | 'break'
+
+type TimerState = {
+	status: TimerStatus
+	secondsRemaining: number
+	durationSeconds: number
+	intention: string
+	sessionId: number | null
+	// actions
+	startTimer: (duration: number, intention: string, sessionId: number) => void
+	pauseTimer: () => void
+	resumeTimer: () => void
+	tick: () => void
+	stopTimer: () => void
+	startBreak: (duration?: number) => void
+	reset: () => void
+}
+
+export const useTimerStore = create<TimerState>((set) => ({
+	status: 'idle',
+	secondsRemaining: 0,
+	durationSeconds: 1500,
+	intention: '',
+	sessionId: null,
+
+	startTimer: (duration, intention, sessionId) =>
+		set({
+			status: 'running',
+			secondsRemaining: duration,
+			durationSeconds: duration,
+			intention,
+			sessionId,
+		}),
+
+	pauseTimer: () => set({ status: 'paused' }),
+
+	resumeTimer: () => set({ status: 'running' }),
+
+	tick: () =>
+		set((state) => {
+			if (state.secondsRemaining <= 1) {
+				return { secondsRemaining: 0 }
+			}
+			return { secondsRemaining: state.secondsRemaining - 1 }
+		}),
+
+	stopTimer: () =>
+		set({
+			status: 'idle',
+			secondsRemaining: 0,
+			intention: '',
+			sessionId: null,
+		}),
+
+	startBreak: (duration = 300) =>
+		set({
+			status: 'break',
+			secondsRemaining: duration,
+			durationSeconds: duration,
+			intention: 'Break',
+			sessionId: null,
+		}),
+
+	reset: () =>
+		set({
+			status: 'idle',
+			secondsRemaining: 0,
+			durationSeconds: 1500,
+			intention: '',
+			sessionId: null,
+		}),
+}))

--- a/app/(private)/flow/use-flow.ts
+++ b/app/(private)/flow/use-flow.ts
@@ -1,0 +1,91 @@
+import { queryOptions } from '@tanstack/react-query'
+import {
+	fetchDomains,
+	fetchProjects,
+	fetchTags,
+	fetchSessions,
+	fetchTodaySessions,
+	fetchCheckIns,
+	fetchRecentSleep,
+	fetchHabitDefinitions,
+	fetchTodayHabitLogs,
+	fetchTodoistTasks,
+	fetchGithubItems,
+} from '@/lib/flow'
+
+export const domainsQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'domains'],
+		queryFn: fetchDomains,
+		staleTime: 60_000,
+	})
+
+export const projectsQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'projects'],
+		queryFn: () => fetchProjects(),
+		staleTime: 60_000,
+	})
+
+export const tagsQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'tags'],
+		queryFn: fetchTags,
+		staleTime: 60_000,
+	})
+
+export const sessionsQuery = (limit = 20) =>
+	queryOptions({
+		queryKey: ['flow', 'sessions', limit],
+		queryFn: () => fetchSessions(limit),
+		staleTime: 10_000,
+	})
+
+export const todaySessionsQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'sessions', 'today'],
+		queryFn: fetchTodaySessions,
+		staleTime: 10_000,
+	})
+
+export const checkInsQuery = (limit = 30) =>
+	queryOptions({
+		queryKey: ['flow', 'check-ins', limit],
+		queryFn: () => fetchCheckIns(limit),
+		staleTime: 30_000,
+	})
+
+export const recentSleepQuery = (days = 7) =>
+	queryOptions({
+		queryKey: ['flow', 'sleep', days],
+		queryFn: () => fetchRecentSleep(days),
+		staleTime: 30_000,
+	})
+
+export const habitDefinitionsQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'habit-definitions'],
+		queryFn: fetchHabitDefinitions,
+		staleTime: 60_000,
+	})
+
+export const todayHabitLogsQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'habit-logs', 'today'],
+		queryFn: fetchTodayHabitLogs,
+		staleTime: 10_000,
+	})
+
+export const todoistTasksQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'todoist'],
+		queryFn: fetchTodoistTasks,
+		staleTime: 120_000,
+	})
+
+export const githubItemsQuery = () =>
+	queryOptions({
+		queryKey: ['flow', 'github'],
+		queryFn: () => fetchGithubItems(),
+		staleTime: 120_000,
+	})

--- a/app/api/flow/github/route.ts
+++ b/app/api/flow/github/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export async function POST(request: Request) {
+	const token = process.env.GITHUB_TOKEN
+	if (!token) {
+		return NextResponse.json(
+			{ error: 'GITHUB_TOKEN not configured' },
+			{ status: 500 },
+		)
+	}
+
+	const authHeader = request.headers.get('authorization')
+	if (!authHeader) {
+		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	const supabase = createClient(
+		process.env.NEXT_PUBLIC_SUPABASE_API_URL!,
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_TOKEN!,
+		{ global: { headers: { Authorization: authHeader } } },
+	)
+
+	const {
+		data: { user },
+		error: authError,
+	} = await supabase.auth.getUser()
+	if (authError || !user) {
+		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	// Fetch recent events for authenticated user
+	const res = await fetch('https://api.github.com/user/events?per_page=100', {
+		headers: {
+			Authorization: `Bearer ${token}`,
+			Accept: 'application/vnd.github+json',
+		},
+	})
+
+	if (!res.ok) {
+		return NextResponse.json(
+			{ error: 'GitHub API error', status: res.status },
+			{ status: 502 },
+		)
+	}
+
+	const events = await res.json()
+
+	// Map events to our schema
+	const rows = events.map(
+		(event: {
+			id: string
+			type: string
+			repo: { name: string }
+			payload: {
+				pull_request?: { title: string; html_url: string; state: string }
+				issue?: { title: string; html_url: string; state: string }
+				commits?: { message: string; url: string }[]
+			}
+			created_at: string
+		}) => {
+			let itemType = 'event'
+			let title = event.type
+			let url: string | null = null
+			let state: string | null = null
+
+			if (event.type === 'PullRequestEvent' && event.payload.pull_request) {
+				itemType = 'pull_request'
+				title = event.payload.pull_request.title
+				url = event.payload.pull_request.html_url
+				state = event.payload.pull_request.state
+			} else if (event.type === 'IssuesEvent' && event.payload.issue) {
+				itemType = 'issue'
+				title = event.payload.issue.title
+				url = event.payload.issue.html_url
+				state = event.payload.issue.state
+			} else if (event.type === 'PushEvent' && event.payload.commits?.length) {
+				itemType = 'commit'
+				title = event.payload.commits[0].message
+			}
+
+			return {
+				user_id: user.id,
+				github_id: event.id,
+				item_type: itemType,
+				repo: event.repo.name,
+				title,
+				url,
+				state,
+				created_at_gh: event.created_at,
+				synced_at: new Date().toISOString(),
+			}
+		},
+	)
+
+	const flowDb = supabase.schema('flow' as 'public')
+	const { error } = await flowDb.from('github_items').upsert(rows, {
+		onConflict: 'user_id,github_id',
+	})
+
+	if (error) {
+		return NextResponse.json({ error: error.message }, { status: 500 })
+	}
+
+	return NextResponse.json({ synced: rows.length })
+}

--- a/app/api/flow/todoist/route.ts
+++ b/app/api/flow/todoist/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export async function POST(request: Request) {
+	const token = process.env.TODOIST_API_TOKEN
+	if (!token) {
+		return NextResponse.json(
+			{ error: 'TODOIST_API_TOKEN not configured' },
+			{ status: 500 },
+		)
+	}
+
+	// Get the user's auth token from the request
+	const authHeader = request.headers.get('authorization')
+	if (!authHeader) {
+		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	const supabase = createClient(
+		process.env.NEXT_PUBLIC_SUPABASE_API_URL!,
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_TOKEN!,
+		{ global: { headers: { Authorization: authHeader } } },
+	)
+
+	const {
+		data: { user },
+		error: authError,
+	} = await supabase.auth.getUser()
+	if (authError || !user) {
+		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	// Fetch active tasks from Todoist
+	const res = await fetch('https://api.todoist.com/rest/v2/tasks', {
+		headers: { Authorization: `Bearer ${token}` },
+	})
+
+	if (!res.ok) {
+		return NextResponse.json(
+			{ error: 'Todoist API error', status: res.status },
+			{ status: 502 },
+		)
+	}
+
+	const tasks = await res.json()
+
+	// Also fetch projects for mapping
+	const projectsRes = await fetch('https://api.todoist.com/rest/v2/projects', {
+		headers: { Authorization: `Bearer ${token}` },
+	})
+	const projects = projectsRes.ok ? await projectsRes.json() : []
+	const projectMap = new Map(
+		projects.map((p: { id: string; name: string }) => [p.id, p.name]),
+	)
+
+	// Upsert into flow.todoist_tasks
+	const flowDb = supabase.schema('flow' as 'public')
+	const rows = tasks.map(
+		(task: {
+			id: string
+			content: string
+			description: string
+			project_id: string
+			priority: number
+			due: { date: string } | null
+			is_completed: boolean
+			labels: string[]
+		}) => ({
+			user_id: user.id,
+			todoist_id: task.id,
+			content: task.content,
+			description: task.description || null,
+			project_name: projectMap.get(task.project_id) || null,
+			priority: task.priority,
+			due_date: task.due?.date || null,
+			is_completed: task.is_completed,
+			labels: task.labels || [],
+			synced_at: new Date().toISOString(),
+		}),
+	)
+
+	const { error } = await flowDb.from('todoist_tasks').upsert(rows, {
+		onConflict: 'user_id,todoist_id',
+	})
+
+	if (error) {
+		return NextResponse.json({ error: error.message }, { status: 500 })
+	}
+
+	return NextResponse.json({ synced: rows.length })
+}

--- a/components/flow/domain-badge.tsx
+++ b/components/flow/domain-badge.tsx
@@ -1,0 +1,21 @@
+import type { LifeDomain } from '@/types/flow'
+
+const DOMAIN_COLORS: Record<string, string> = {
+	'Work/Creative': 'bg-blue-100 text-blue-700',
+	Health: 'bg-green-100 text-green-700',
+	Social: 'bg-purple-100 text-purple-700',
+	Chores: 'bg-amber-100 text-amber-700',
+	'Play/Rest': 'bg-pink-100 text-pink-700',
+}
+
+export default function DomainBadge({ domain }: { domain: LifeDomain }) {
+	const colors = DOMAIN_COLORS[domain.name] || 'bg-gray-100 text-gray-700'
+	return (
+		<span
+			className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs ${colors}`}
+		>
+			{domain.icon && <span>{domain.icon}</span>}
+			{domain.name}
+		</span>
+	)
+}

--- a/components/flow/habit-toggle.tsx
+++ b/components/flow/habit-toggle.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import type { HabitDefinition } from '@/types/flow'
+
+export default function HabitToggle({
+	habit,
+	done,
+	onToggle,
+}: {
+	habit: HabitDefinition
+	done: boolean
+	onToggle: (done: boolean) => void
+}) {
+	return (
+		<button
+			type="button"
+			onClick={() => onToggle(!done)}
+			className={`flex items-center gap-2 px-4 py-3 rounded-xl text-left transition-colors ${
+				done
+					? 'bg-gray-100 text-gray-700'
+					: 'bg-white text-gray-400 border border-gray-200'
+			}`}
+		>
+			<span className="text-xl">
+				{habit.icon || (done ? '\u2713' : '\u25cb')}
+			</span>
+			<span className={done ? '' : 'opacity-60'}>{habit.name}</span>
+		</button>
+	)
+}

--- a/components/flow/habit-toggle.tsx
+++ b/components/flow/habit-toggle.tsx
@@ -17,8 +17,8 @@ export default function HabitToggle({
 			onClick={() => onToggle(!done)}
 			className={`flex items-center gap-2 px-4 py-3 rounded-xl text-left transition-colors ${
 				done
-					? 'bg-gray-100 text-gray-700'
-					: 'bg-white text-gray-400 border border-gray-200'
+					? 'bg-cyan/10 text-gray-700 border border-cyan-soft'
+					: 'bg-flow-surface-alt text-flow-muted border border-flow-border'
 			}`}
 		>
 			<span className="text-xl">

--- a/components/flow/mini-timer.tsx
+++ b/components/flow/mini-timer.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useTimerStore } from '@/app/(private)/flow/timer/timer-store'
+import Link from 'next/link'
+
+function formatTime(seconds: number) {
+	const m = Math.floor(seconds / 60)
+	const s = seconds % 60
+	return `${m}:${String(s).padStart(2, '0')}`
+}
+
+export default function MiniTimer() {
+	const status = useTimerStore((s) => s.status)
+	const secondsRemaining = useTimerStore((s) => s.secondsRemaining)
+	const intention = useTimerStore((s) => s.intention)
+
+	if (status === 'idle') return null
+
+	const isBreak = status === 'break'
+
+	return (
+		<Link
+			href="/flow"
+			className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm font-display tabular-nums ${
+				isBreak
+					? 'bg-green-100 text-green-700'
+					: status === 'paused'
+						? 'bg-gray-100 text-gray-500'
+						: 'bg-cyan/10 text-cyan-bright'
+			}`}
+		>
+			<span
+				className={`w-2 h-2 rounded-full ${
+					isBreak
+						? 'bg-green-500'
+						: status === 'paused'
+							? 'bg-gray-400'
+							: 'bg-cyan-bright animate-pulse'
+				}`}
+			/>
+			<span>{formatTime(secondsRemaining)}</span>
+			{intention && (
+				<span className="hidden sm:inline text-xs opacity-70 max-w-[10rem] truncate">
+					{intention}
+				</span>
+			)}
+		</Link>
+	)
+}

--- a/components/flow/scale-input.tsx
+++ b/components/flow/scale-input.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+export default function ScaleInput({
+	value,
+	onChange,
+	labels,
+}: {
+	value: number | null
+	onChange: (v: number | null) => void
+	labels?: [string, string]
+}) {
+	return (
+		<div className="flex flex-col gap-1">
+			<div className="flex gap-1">
+				{[1, 2, 3, 4, 5].map((n) => (
+					<button
+						key={n}
+						type="button"
+						onClick={() => onChange(value === n ? null : n)}
+						className={`flex-1 py-3 rounded-lg text-lg font-medium transition-colors min-w-[3rem] ${
+							value === n
+								? 'bg-cyan text-white'
+								: 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+						}`}
+					>
+						{n}
+					</button>
+				))}
+			</div>
+			{labels && (
+				<div className="flex justify-between text-xs text-gray-400 px-1">
+					<span>{labels[0]}</span>
+					<span>{labels[1]}</span>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/components/flow/scale-input.tsx
+++ b/components/flow/scale-input.tsx
@@ -19,8 +19,8 @@ export default function ScaleInput({
 						onClick={() => onChange(value === n ? null : n)}
 						className={`flex-1 py-3 rounded-lg text-lg font-medium transition-colors min-w-[3rem] ${
 							value === n
-								? 'bg-cyan text-white'
-								: 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+								? 'bg-cyan text-white shadow-sm'
+								: 'bg-flow-surface-alt border border-flow-border text-flow-muted hover:bg-flow-bg hover:border-flow-muted/40'
 						}`}
 					>
 						{n}
@@ -28,7 +28,7 @@ export default function ScaleInput({
 				))}
 			</div>
 			{labels && (
-				<div className="flex justify-between text-xs text-gray-400 px-1">
+				<div className="flex justify-between text-xs text-flow-muted px-1">
 					<span>{labels[0]}</span>
 					<span>{labels[1]}</span>
 				</div>

--- a/components/flow/sleep-log.tsx
+++ b/components/flow/sleep-log.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { upsertSleepLog } from '@/lib/flow'
+import type { SleepLog as SleepLogType } from '@/types/flow'
+
+const PRESETS = [5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9]
+
+const FEELING_EMOJIS = [
+	{ emoji: '\ud83d\ude35\u200d\ud83d\udcab', label: 'rough' },
+	{ emoji: '\ud83d\ude34', label: 'groggy' },
+	{ emoji: '\ud83d\ude10', label: 'meh' },
+	{ emoji: '\ud83d\ude0c', label: 'rested' },
+	{ emoji: '\ud83d\ude0a', label: 'content' },
+	{ emoji: '\u26a1', label: 'energized' },
+]
+
+export default function SleepLog({
+	existing,
+}: {
+	existing?: SleepLogType | null
+}) {
+	const [hours, setHours] = useState<number | null>(
+		existing?.hours_slept ?? null,
+	)
+	const [feeling, setFeeling] = useState<string | null>(existing?.notes ?? null)
+	const [saved, setSaved] = useState(false)
+	const queryClient = useQueryClient()
+
+	// Sync when existing data loads
+	useEffect(() => {
+		if (existing?.hours_slept != null) setHours(existing.hours_slept)
+		if (existing?.notes) setFeeling(existing.notes)
+	}, [existing?.hours_slept, existing?.notes])
+
+	const save = useMutation({
+		mutationFn: (opts: { h: number; f: string | null }) =>
+			upsertSleepLog({
+				date: new Date().toISOString().split('T')[0],
+				hours_slept: opts.h,
+				quality: null,
+				bedtime: null,
+				wake_time: null,
+				notes: opts.f,
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['flow', 'sleep'] })
+			setSaved(true)
+			setTimeout(() => setSaved(false), 1500)
+		},
+	})
+
+	const selectHours = (h: number) => {
+		setHours(h)
+		save.mutate({ h, f: feeling })
+	}
+
+	const nudge = (delta: number) => {
+		const next = Math.max(0, Math.min(24, (hours ?? 7) + delta))
+		setHours(next)
+		save.mutate({ h: next, f: feeling })
+	}
+
+	const selectFeeling = (emoji: string) => {
+		const next = feeling === emoji ? null : emoji
+		setFeeling(next)
+		if (hours != null) save.mutate({ h: hours, f: next })
+	}
+
+	return (
+		<div className="flex flex-col gap-3 p-4 rounded-xl bg-white border">
+			<div className="flex items-center justify-between">
+				<p className="text-sm text-gray-500">How&apos;d you sleep?</p>
+				{saved && <span className="text-xs text-green-600">Saved</span>}
+			</div>
+
+			{/* Hour presets */}
+			<div className="flex items-center gap-1">
+				<button
+					onClick={() => nudge(-0.5)}
+					className="px-2 py-2 rounded-lg text-gray-400 hover:bg-gray-100 text-lg"
+				>
+					&minus;
+				</button>
+				<div className="flex gap-1 flex-1 justify-center flex-wrap">
+					{PRESETS.map((h) => (
+						<button
+							key={h}
+							onClick={() => selectHours(h)}
+							className={`px-2.5 py-2 rounded-lg text-sm tabular-nums transition-colors ${
+								hours === h
+									? 'bg-cyan text-white'
+									: 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+							}`}
+						>
+							{h % 1 === 0 ? h : h.toFixed(1)}
+						</button>
+					))}
+				</div>
+				<button
+					onClick={() => nudge(0.5)}
+					className="px-2 py-2 rounded-lg text-gray-400 hover:bg-gray-100 text-lg"
+				>
+					+
+				</button>
+			</div>
+
+			{/* Current value display when not a preset */}
+			{hours != null && !PRESETS.includes(hours) && (
+				<p className="text-center text-sm text-gray-500">{hours}h</p>
+			)}
+
+			{/* Feeling emojis */}
+			<div className="flex justify-center gap-2">
+				{FEELING_EMOJIS.map(({ emoji, label }) => (
+					<button
+						key={label}
+						onClick={() => selectFeeling(emoji)}
+						title={label}
+						className={`text-2xl p-1.5 rounded-lg transition-all ${
+							feeling === emoji
+								? 'bg-gray-100 scale-110'
+								: 'opacity-50 hover:opacity-80'
+						}`}
+					>
+						{emoji}
+					</button>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/components/flow/sleep-log.tsx
+++ b/components/flow/sleep-log.tsx
@@ -69,9 +69,9 @@ export default function SleepLog({
 	}
 
 	return (
-		<div className="flex flex-col gap-3 p-4 rounded-xl bg-white border">
+		<div className="flow-card-interactive flex flex-col gap-3">
 			<div className="flex items-center justify-between">
-				<p className="text-sm text-gray-500">How&apos;d you sleep?</p>
+				<h2 className="flow-section-heading">How&apos;d you sleep?</h2>
 				{saved && <span className="text-xs text-green-600">Saved</span>}
 			</div>
 
@@ -79,7 +79,7 @@ export default function SleepLog({
 			<div className="flex items-center gap-1">
 				<button
 					onClick={() => nudge(-0.5)}
-					className="px-2 py-2 rounded-lg text-gray-400 hover:bg-gray-100 text-lg"
+					className="px-2 py-2 rounded-lg text-flow-muted hover:bg-flow-surface-alt text-lg"
 				>
 					&minus;
 				</button>
@@ -90,8 +90,8 @@ export default function SleepLog({
 							onClick={() => selectHours(h)}
 							className={`px-2.5 py-2 rounded-lg text-sm tabular-nums transition-colors ${
 								hours === h
-									? 'bg-cyan text-white'
-									: 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+									? 'bg-cyan text-white shadow-sm'
+									: 'bg-flow-surface-alt border border-flow-border text-flow-muted hover:bg-flow-bg'
 							}`}
 						>
 							{h % 1 === 0 ? h : h.toFixed(1)}
@@ -100,7 +100,7 @@ export default function SleepLog({
 				</div>
 				<button
 					onClick={() => nudge(0.5)}
-					className="px-2 py-2 rounded-lg text-gray-400 hover:bg-gray-100 text-lg"
+					className="px-2 py-2 rounded-lg text-flow-muted hover:bg-flow-surface-alt text-lg"
 				>
 					+
 				</button>
@@ -120,7 +120,7 @@ export default function SleepLog({
 						title={label}
 						className={`text-2xl p-1.5 rounded-lg transition-all ${
 							feeling === emoji
-								? 'bg-gray-100 scale-110'
+								? 'bg-flow-surface-alt border border-flow-border scale-110'
 								: 'opacity-50 hover:opacity-80'
 						}`}
 					>

--- a/components/flow/tag-picker.tsx
+++ b/components/flow/tag-picker.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { tagsQuery } from '@/app/(private)/flow/use-flow'
+import { createTag } from '@/lib/flow'
+import type { Tag } from '@/types/flow'
+
+export default function TagPicker({
+	selected,
+	onChange,
+}: {
+	selected: number[]
+	onChange: (ids: number[]) => void
+}) {
+	const [filter, setFilter] = useState('')
+	const { data: tags = [] } = useQuery(tagsQuery())
+	const queryClient = useQueryClient()
+
+	const addTag = useMutation({
+		mutationFn: (name: string) =>
+			createTag({ name, source: 'user', domain_id: null, project_id: null }),
+		onSuccess: (newTag) => {
+			queryClient.invalidateQueries({ queryKey: ['flow', 'tags'] })
+			onChange([...selected, newTag.id])
+			setFilter('')
+		},
+	})
+
+	const filtered = tags.filter((t) =>
+		t.name.toLowerCase().includes(filter.toLowerCase()),
+	)
+
+	const toggle = (id: number) => {
+		onChange(
+			selected.includes(id)
+				? selected.filter((s) => s !== id)
+				: [...selected, id],
+		)
+	}
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === 'Enter' && filter && filtered.length === 0) {
+			e.preventDefault()
+			addTag.mutate(filter)
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-2">
+			<input
+				type="text"
+				value={filter}
+				onChange={(e) => setFilter(e.target.value)}
+				onKeyDown={handleKeyDown}
+				placeholder="Search or create tag..."
+				className="border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent text-sm"
+			/>
+			<div className="flex flex-wrap gap-1">
+				{filtered.slice(0, 20).map((tag) => (
+					<button
+						key={tag.id}
+						type="button"
+						onClick={() => toggle(tag.id)}
+						className={`px-2 py-1 rounded text-xs transition-colors ${
+							selected.includes(tag.id)
+								? 'bg-cyan text-white'
+								: 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+						}`}
+					>
+						{tag.name}
+					</button>
+				))}
+				{filter && filtered.length === 0 && (
+					<button
+						type="button"
+						onClick={() => addTag.mutate(filter)}
+						className="px-2 py-1 rounded text-xs bg-cyan/10 text-cyan-bright hover:bg-cyan/20"
+					>
+						+ Create &ldquo;{filter}&rdquo;
+					</button>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/components/flow/tag-picker.tsx
+++ b/components/flow/tag-picker.tsx
@@ -54,7 +54,7 @@ export default function TagPicker({
 				onChange={(e) => setFilter(e.target.value)}
 				onKeyDown={handleKeyDown}
 				placeholder="Search or create tag..."
-				className="border-b border-gray-300 focus:border-cyan focus:outline-none py-1 bg-transparent text-sm"
+				className="border border-flow-border rounded-lg px-2 py-1.5 bg-flow-surface-alt focus:border-cyan focus:ring-1 focus:ring-flow-input-ring focus:outline-none text-sm"
 			/>
 			<div className="flex flex-wrap gap-1">
 				{filtered.slice(0, 20).map((tag) => (
@@ -65,7 +65,7 @@ export default function TagPicker({
 						className={`px-2 py-1 rounded text-xs transition-colors ${
 							selected.includes(tag.id)
 								? 'bg-cyan text-white'
-								: 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+								: 'bg-flow-surface-alt border border-flow-border text-flow-muted hover:bg-flow-bg'
 						}`}
 					>
 						{tag.name}

--- a/components/menu.tsx
+++ b/components/menu.tsx
@@ -12,6 +12,7 @@ export default function Menu() {
 		session?.user?.email?.split(/[\b\@\.]/)[0] || 'editor'
 	const loggedInLinks = session
 		? [
+				['Flow', '/flow'],
 				['Drafts', '/posts/drafts'],
 				['Compose', '/posts/new'],
 			]

--- a/lib/flow.ts
+++ b/lib/flow.ts
@@ -1,0 +1,288 @@
+import supabase from '@/app/supabase-client'
+import type {
+	LifeDomain,
+	LifeDomainInsert,
+	Project,
+	ProjectInsert,
+	Tag,
+	TagInsert,
+	PomodoroSession,
+	PomodoroSessionInsert,
+	CheckIn,
+	CheckInInsert,
+	SleepLog,
+	SleepLogInsert,
+	HabitDefinition,
+	HabitDefinitionInsert,
+	HabitLog,
+	TodoistTask,
+	GithubItem,
+} from '@/types/flow'
+
+const flow = () => supabase.schema('flow')
+
+// =============================================================================
+// LIFE DOMAINS
+// =============================================================================
+
+export async function fetchDomains(): Promise<LifeDomain[]> {
+	const { data, error } = await flow()
+		.from('life_domains')
+		.select('*')
+		.eq('is_active', true)
+		.order('sort_order')
+	if (error) throw error
+	return data as LifeDomain[]
+}
+
+export async function upsertDomain(
+	domain: LifeDomainInsert & { id?: number },
+): Promise<LifeDomain> {
+	const { data, error } = await flow()
+		.from('life_domains')
+		.upsert(domain)
+		.select()
+		.single()
+	if (error) throw error
+	return data as LifeDomain
+}
+
+// =============================================================================
+// PROJECTS
+// =============================================================================
+
+export async function fetchProjects(activeOnly = true): Promise<Project[]> {
+	let query = flow()
+		.from('projects')
+		.select('*')
+		.order('is_priority', { ascending: false })
+	if (activeOnly) query = query.eq('is_active', true)
+	const { data, error } = await query
+	if (error) throw error
+	return data as Project[]
+}
+
+export async function upsertProject(
+	project: ProjectInsert & { id?: number },
+): Promise<Project> {
+	const { data, error } = await flow()
+		.from('projects')
+		.upsert(project)
+		.select()
+		.single()
+	if (error) throw error
+	return data as Project
+}
+
+// =============================================================================
+// TAGS
+// =============================================================================
+
+export async function fetchTags(): Promise<Tag[]> {
+	const { data, error } = await flow().from('tags').select('*').order('name')
+	if (error) throw error
+	return data as Tag[]
+}
+
+export async function createTag(tag: TagInsert): Promise<Tag> {
+	const { data, error } = await flow()
+		.from('tags')
+		.insert(tag)
+		.select()
+		.single()
+	if (error) throw error
+	return data as Tag
+}
+
+// =============================================================================
+// POMODORO SESSIONS
+// =============================================================================
+
+export async function fetchSessions(limit = 20): Promise<PomodoroSession[]> {
+	const { data, error } = await flow()
+		.from('pomodoro_sessions')
+		.select('*')
+		.order('started_at', { ascending: false })
+		.limit(limit)
+	if (error) throw error
+	return data as PomodoroSession[]
+}
+
+export async function fetchTodaySessions(): Promise<PomodoroSession[]> {
+	const today = new Date().toISOString().split('T')[0]
+	const { data, error } = await flow()
+		.from('pomodoro_sessions')
+		.select('*')
+		.gte('started_at', `${today}T00:00:00`)
+		.order('started_at', { ascending: false })
+	if (error) throw error
+	return data as PomodoroSession[]
+}
+
+export async function createSession(
+	session: Partial<PomodoroSessionInsert>,
+): Promise<PomodoroSession> {
+	const { data, error } = await flow()
+		.from('pomodoro_sessions')
+		.insert({
+			started_at: new Date().toISOString(),
+			duration_seconds: session.duration_seconds ?? 1500,
+			intention: session.intention ?? null,
+			status: 'running',
+			...session,
+		})
+		.select()
+		.single()
+	if (error) throw error
+	return data as PomodoroSession
+}
+
+export async function updateSession(
+	id: number,
+	updates: Partial<PomodoroSession>,
+): Promise<PomodoroSession> {
+	const { data, error } = await flow()
+		.from('pomodoro_sessions')
+		.update(updates)
+		.eq('id', id)
+		.select()
+		.single()
+	if (error) throw error
+	return data as PomodoroSession
+}
+
+export async function addSessionTags(
+	sessionId: number,
+	tagIds: number[],
+): Promise<void> {
+	const rows = tagIds.map((tag_id) => ({ session_id: sessionId, tag_id }))
+	const { error } = await flow().from('session_tags').upsert(rows)
+	if (error) throw error
+}
+
+// =============================================================================
+// CHECK-INS
+// =============================================================================
+
+export async function fetchCheckIns(limit = 30): Promise<CheckIn[]> {
+	const { data, error } = await flow()
+		.from('check_ins')
+		.select('*')
+		.order('created_at', { ascending: false })
+		.limit(limit)
+	if (error) throw error
+	return data as CheckIn[]
+}
+
+export async function createCheckIn(checkIn: CheckInInsert): Promise<CheckIn> {
+	const { data, error } = await flow()
+		.from('check_ins')
+		.insert(checkIn)
+		.select()
+		.single()
+	if (error) throw error
+	return data as CheckIn
+}
+
+// =============================================================================
+// SLEEP LOGS
+// =============================================================================
+
+export async function fetchRecentSleep(days = 7): Promise<SleepLog[]> {
+	const since = new Date()
+	since.setDate(since.getDate() - days)
+	const { data, error } = await flow()
+		.from('sleep_logs')
+		.select('*')
+		.gte('date', since.toISOString().split('T')[0])
+		.order('date', { ascending: false })
+	if (error) throw error
+	return data as SleepLog[]
+}
+
+export async function upsertSleepLog(log: SleepLogInsert): Promise<SleepLog> {
+	const { data, error } = await flow()
+		.from('sleep_logs')
+		.upsert(log, { onConflict: 'user_id,date' })
+		.select()
+		.single()
+	if (error) throw error
+	return data as SleepLog
+}
+
+// =============================================================================
+// HABIT DEFINITIONS & LOGS
+// =============================================================================
+
+export async function fetchHabitDefinitions(): Promise<HabitDefinition[]> {
+	const { data, error } = await flow()
+		.from('habit_definitions')
+		.select('*')
+		.eq('is_active', true)
+		.order('sort_order')
+	if (error) throw error
+	return data as HabitDefinition[]
+}
+
+export async function upsertHabitDefinition(
+	habit: HabitDefinitionInsert & { id?: number },
+): Promise<HabitDefinition> {
+	const { data, error } = await flow()
+		.from('habit_definitions')
+		.upsert(habit)
+		.select()
+		.single()
+	if (error) throw error
+	return data as HabitDefinition
+}
+
+export async function fetchTodayHabitLogs(): Promise<HabitLog[]> {
+	const today = new Date().toISOString().split('T')[0]
+	const { data, error } = await flow()
+		.from('habit_logs')
+		.select('*')
+		.eq('date', today)
+	if (error) throw error
+	return data as HabitLog[]
+}
+
+export async function toggleHabitLog(
+	habitDefinitionId: number,
+	date: string,
+	done: boolean,
+): Promise<HabitLog> {
+	const { data, error } = await flow()
+		.from('habit_logs')
+		.upsert(
+			{ habit_definition_id: habitDefinitionId, date, done },
+			{ onConflict: 'habit_definition_id,date' },
+		)
+		.select()
+		.single()
+	if (error) throw error
+	return data as HabitLog
+}
+
+// =============================================================================
+// TODOIST & GITHUB CACHES
+// =============================================================================
+
+export async function fetchTodoistTasks(): Promise<TodoistTask[]> {
+	const { data, error } = await flow()
+		.from('todoist_tasks')
+		.select('*')
+		.eq('is_completed', false)
+		.order('priority', { ascending: false })
+	if (error) throw error
+	return data as TodoistTask[]
+}
+
+export async function fetchGithubItems(limit = 50): Promise<GithubItem[]> {
+	const { data, error } = await flow()
+		.from('github_items')
+		.select('*')
+		.order('created_at_gh', { ascending: false })
+		.limit(limit)
+	if (error) throw error
+	return data as GithubItem[]
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"remark-react": "^8.0.0",
 		"timeago.js": "^4.0.2",
 		"unified": "^9.2.2",
-		"zod": "^4.0.10"
+		"zod": "^4.0.10",
+		"zustand": "^5.0.11"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       zod:
         specifier: ^4.0.10
         version: 4.0.10
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/react@18.3.8)(react@18.3.1)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.8
@@ -3021,6 +3024,24 @@ packages:
 
   zod@4.0.10:
     resolution: {integrity: sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==}
+
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -6220,3 +6241,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@4.0.10: {}
+
+  zustand@5.0.11(@types/react@18.3.8)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.8
+      react: 18.3.1

--- a/public/flow-manifest.json
+++ b/public/flow-manifest.json
@@ -1,0 +1,28 @@
+{
+	"name": "Flow",
+	"short_name": "Flow",
+	"description": "Personal activity & wellbeing tracker",
+	"start_url": "/flow",
+	"scope": "/flow",
+	"display": "standalone",
+	"background_color": "#f9fafb",
+	"theme_color": "#0087c1",
+	"icons": [
+		{
+			"src": "/images/flow-icon-192.svg",
+			"sizes": "192x192",
+			"type": "image/svg+xml"
+		},
+		{
+			"src": "/images/flow-icon-512.svg",
+			"sizes": "512x512",
+			"type": "image/svg+xml"
+		},
+		{
+			"src": "/images/flow-icon-512.svg",
+			"sizes": "512x512",
+			"type": "image/svg+xml",
+			"purpose": "maskable"
+		}
+	]
+}

--- a/public/flow-sw.js
+++ b/public/flow-sw.js
@@ -1,0 +1,81 @@
+const CACHE_NAME = 'flow-v1'
+
+const PRECACHE_URLS = [
+	'/flow',
+	'/flow/check-in',
+	'/flow/domains',
+	'/flow/history',
+	'/flow/settings',
+]
+
+self.addEventListener('install', (event) => {
+	event.waitUntil(
+		caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS)),
+	)
+	self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil(
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(
+					keys
+						.filter((key) => key !== CACHE_NAME)
+						.map((key) => caches.delete(key)),
+				),
+			),
+	)
+	self.clients.claim()
+})
+
+self.addEventListener('fetch', (event) => {
+	const url = new URL(event.request.url)
+
+	// Only handle same-origin navigation requests under /flow
+	if (url.origin !== self.location.origin) return
+	if (!url.pathname.startsWith('/flow')) return
+
+	// Skip API and supabase requests — always go to network
+	if (url.pathname.startsWith('/api/')) return
+	if (url.hostname.includes('supabase')) return
+
+	// Network-first for HTML pages, cache as fallback
+	if (event.request.mode === 'navigate') {
+		event.respondWith(
+			fetch(event.request)
+				.then((response) => {
+					const clone = response.clone()
+					caches
+						.open(CACHE_NAME)
+						.then((cache) => cache.put(event.request, clone))
+					return response
+				})
+				.catch(() => caches.match(event.request)),
+		)
+		return
+	}
+
+	// Cache-first for static assets (JS, CSS, fonts, images)
+	if (
+		event.request.destination === 'script' ||
+		event.request.destination === 'style' ||
+		event.request.destination === 'font' ||
+		event.request.destination === 'image'
+	) {
+		event.respondWith(
+			caches.match(event.request).then(
+				(cached) =>
+					cached ||
+					fetch(event.request).then((response) => {
+						const clone = response.clone()
+						caches
+							.open(CACHE_NAME)
+							.then((cache) => cache.put(event.request, clone))
+						return response
+					}),
+			),
+		)
+	}
+})

--- a/public/images/flow-icon-192.svg
+++ b/public/images/flow-icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="40" fill="#0087c1"/>
+  <text x="96" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="300" font-size="120" fill="white">F</text>
+</svg>

--- a/public/images/flow-icon-512.svg
+++ b/public/images/flow-icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="108" fill="#0087c1"/>
+  <text x="256" y="346" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="300" font-size="320" fill="white">F</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -25,11 +25,45 @@ layer(base);
 	--color-lilac-bright: #d696d8;
 	--color-lilac-content: #905d91;
 	--color-lilac-soft: #e2d3e3;
+
+	/* Flow app palette */
+	--color-flow-bg: #e8ecf1;
+	--color-flow-surface: #ffffff;
+	--color-flow-surface-alt: #f3f5f8;
+	--color-flow-border: #cdd3dc;
+	--color-flow-muted: #667085;
+	--color-flow-heading: #475467;
+	--color-flow-input-ring: #b8d4e3;
 }
 
 @utility container {
 	margin-inline: auto;
 	padding-inline: 1.25rem;
+}
+
+@utility flow-card {
+	background: var(--color-flow-surface);
+	border: 1px solid var(--color-flow-border);
+	border-radius: 0.75rem;
+	padding: 1rem 1.25rem;
+	box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+}
+
+@utility flow-card-interactive {
+	background: var(--color-flow-surface);
+	border: 1px solid var(--color-flow-border);
+	border-left: 3px solid var(--color-cyan-soft);
+	border-radius: 0.75rem;
+	padding: 1rem 1.25rem;
+	box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+}
+
+@utility flow-section-heading {
+	font-size: 0.7rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	color: var(--color-flow-heading);
 }
 
 /*

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -8,7 +8,7 @@ enabled = true
 port = 54321
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` is always included.
-schemas = ["public", "storage", "whup", "mortality"]
+schemas = ["public", "storage", "whup", "mortality", "flow"]
 # Extra schemas to add to the search_path of every request. `public` is always included.
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size

--- a/supabase/migrations/20260215000000_flow_schema.sql
+++ b/supabase/migrations/20260215000000_flow_schema.sql
@@ -1,0 +1,219 @@
+-- Flow: Personal Activity & Wellbeing Tracker
+-- Tracks pomodoro sessions, mood/energy check-ins, habits, sleep, and life domains
+
+CREATE SCHEMA IF NOT EXISTS flow;
+
+GRANT USAGE ON SCHEMA flow TO anon, authenticated, service_role;
+
+-- =============================================================================
+-- TABLES
+-- =============================================================================
+
+-- Life domains: configurable categories of activity
+CREATE TABLE flow.life_domains (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  name text NOT NULL,
+  icon text, -- emoji
+  color text, -- tailwind color name or hex
+  sort_order integer NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Projects linked to domains
+CREATE TABLE flow.projects (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  domain_id integer REFERENCES flow.life_domains(id) ON DELETE SET NULL,
+  name text NOT NULL,
+  description text,
+  is_priority boolean NOT NULL DEFAULT false,
+  target_pct numeric CHECK (target_pct IS NULL OR (target_pct >= 0 AND target_pct <= 100)),
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Tags for sessions and items
+CREATE TABLE flow.tags (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  name text NOT NULL,
+  domain_id integer REFERENCES flow.life_domains(id) ON DELETE SET NULL,
+  project_id integer REFERENCES flow.projects(id) ON DELETE SET NULL,
+  source text NOT NULL DEFAULT 'user' CHECK (source IN ('user', 'suggested', 'todoist', 'github')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, name)
+);
+
+-- Pomodoro timer sessions
+CREATE TABLE flow.pomodoro_sessions (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  started_at timestamptz NOT NULL DEFAULT now(),
+  ended_at timestamptz,
+  duration_seconds integer NOT NULL DEFAULT 1500, -- 25 min default
+  intention text,
+  status text NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'paused', 'completed', 'abandoned')),
+  mood smallint CHECK (mood IS NULL OR (mood >= 1 AND mood <= 5)),
+  energy smallint CHECK (energy IS NULL OR (energy >= 1 AND energy <= 5)),
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Many-to-many: sessions <-> tags
+CREATE TABLE flow.session_tags (
+  id serial PRIMARY KEY,
+  session_id integer NOT NULL REFERENCES flow.pomodoro_sessions(id) ON DELETE CASCADE,
+  tag_id integer NOT NULL REFERENCES flow.tags(id) ON DELETE CASCADE,
+  UNIQUE (session_id, tag_id)
+);
+
+-- Mood/energy check-ins
+CREATE TABLE flow.check_ins (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  anxiety smallint CHECK (anxiety IS NULL OR (anxiety >= 1 AND anxiety <= 5)),
+  depression smallint CHECK (depression IS NULL OR (depression >= 1 AND depression <= 5)),
+  energy smallint CHECK (energy IS NULL OR (energy >= 1 AND energy <= 5)),
+  ease smallint CHECK (ease IS NULL OR (ease >= 1 AND ease <= 5)),
+  flow smallint CHECK (flow IS NULL OR (flow >= 1 AND flow <= 5)),
+  focus smallint CHECK (focus IS NULL OR (focus >= 1 AND focus <= 5)),
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Sleep tracking
+CREATE TABLE flow.sleep_logs (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  date date NOT NULL DEFAULT CURRENT_DATE,
+  hours_slept numeric CHECK (hours_slept IS NULL OR (hours_slept >= 0 AND hours_slept <= 24)),
+  quality smallint CHECK (quality IS NULL OR (quality >= 1 AND quality <= 5)),
+  bedtime time,
+  wake_time time,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, date)
+);
+
+-- User-configurable habit definitions
+CREATE TABLE flow.habit_definitions (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  name text NOT NULL,
+  icon text, -- emoji
+  domain_id integer REFERENCES flow.life_domains(id) ON DELETE SET NULL,
+  category text NOT NULL DEFAULT 'positive' CHECK (category IN ('positive', 'neutral')),
+  sort_order integer NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Daily habit entries
+CREATE TABLE flow.habit_logs (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  habit_definition_id integer NOT NULL REFERENCES flow.habit_definitions(id) ON DELETE CASCADE,
+  date date NOT NULL DEFAULT CURRENT_DATE,
+  done boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (habit_definition_id, date)
+);
+
+-- Cache of Todoist tasks
+CREATE TABLE flow.todoist_tasks (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  todoist_id text NOT NULL,
+  content text NOT NULL,
+  description text,
+  project_name text,
+  priority integer,
+  due_date text,
+  is_completed boolean NOT NULL DEFAULT false,
+  labels text[], -- array of label strings
+  synced_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, todoist_id)
+);
+
+-- Cache of GitHub issues/PRs/commits
+CREATE TABLE flow.github_items (
+  id serial PRIMARY KEY,
+  user_id uuid NOT NULL DEFAULT auth.uid() REFERENCES auth.users(id),
+  github_id text NOT NULL,
+  item_type text NOT NULL CHECK (item_type IN ('issue', 'pull_request', 'commit', 'event')),
+  repo text NOT NULL,
+  title text,
+  url text,
+  state text,
+  created_at_gh timestamptz,
+  synced_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, github_id)
+);
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+CREATE INDEX idx_sessions_user ON flow.pomodoro_sessions(user_id);
+CREATE INDEX idx_sessions_started ON flow.pomodoro_sessions(started_at);
+CREATE INDEX idx_sessions_status ON flow.pomodoro_sessions(status);
+CREATE INDEX idx_checkins_user ON flow.check_ins(user_id);
+CREATE INDEX idx_checkins_created ON flow.check_ins(created_at);
+CREATE INDEX idx_sleep_user_date ON flow.sleep_logs(user_id, date);
+CREATE INDEX idx_habits_user ON flow.habit_definitions(user_id);
+CREATE INDEX idx_habit_logs_date ON flow.habit_logs(date);
+CREATE INDEX idx_habit_logs_habit ON flow.habit_logs(habit_definition_id);
+CREATE INDEX idx_tags_user ON flow.tags(user_id);
+CREATE INDEX idx_todoist_user ON flow.todoist_tasks(user_id);
+CREATE INDEX idx_github_user ON flow.github_items(user_id);
+
+-- =============================================================================
+-- ROW LEVEL SECURITY
+-- =============================================================================
+
+ALTER TABLE flow.life_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.pomodoro_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.session_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.check_ins ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.sleep_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.habit_definitions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.habit_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.todoist_tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE flow.github_items ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users: full access to own rows
+CREATE POLICY "Users manage own data" ON flow.life_domains FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.projects FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.tags FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.pomodoro_sessions FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own session_tags" ON flow.session_tags FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM flow.pomodoro_sessions s WHERE s.id = session_id AND s.user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM flow.pomodoro_sessions s WHERE s.id = session_id AND s.user_id = auth.uid()));
+CREATE POLICY "Users manage own data" ON flow.check_ins FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.sleep_logs FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.habit_definitions FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.habit_logs FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.todoist_tasks FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users manage own data" ON flow.github_items FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+-- =============================================================================
+-- GRANTS
+-- =============================================================================
+
+GRANT ALL ON ALL TABLES IN SCHEMA flow TO authenticated;
+GRANT ALL ON ALL TABLES IN SCHEMA flow TO service_role;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA flow TO authenticated, service_role;

--- a/types/flow.ts
+++ b/types/flow.ts
@@ -1,0 +1,148 @@
+// Types for the flow schema
+// Manually defined since the schema is separate from auto-generated public types
+
+export type LifeDomain = {
+	id: number
+	user_id: string
+	name: string
+	icon: string | null
+	color: string | null
+	sort_order: number
+	is_active: boolean
+	created_at: string
+}
+
+export type Project = {
+	id: number
+	user_id: string
+	domain_id: number | null
+	name: string
+	description: string | null
+	is_priority: boolean
+	target_pct: number | null
+	is_active: boolean
+	created_at: string
+}
+
+export type Tag = {
+	id: number
+	user_id: string
+	name: string
+	domain_id: number | null
+	project_id: number | null
+	source: 'user' | 'suggested' | 'todoist' | 'github'
+	created_at: string
+}
+
+export type SessionStatus = 'running' | 'paused' | 'completed' | 'abandoned'
+
+export type PomodoroSession = {
+	id: number
+	user_id: string
+	started_at: string
+	ended_at: string | null
+	duration_seconds: number
+	intention: string | null
+	status: SessionStatus
+	mood: number | null
+	energy: number | null
+	notes: string | null
+	created_at: string
+}
+
+export type SessionTag = {
+	id: number
+	session_id: number
+	tag_id: number
+}
+
+export type CheckIn = {
+	id: number
+	user_id: string
+	anxiety: number | null
+	depression: number | null
+	energy: number | null
+	ease: number | null
+	flow: number | null
+	focus: number | null
+	notes: string | null
+	created_at: string
+}
+
+export type SleepLog = {
+	id: number
+	user_id: string
+	date: string
+	hours_slept: number | null
+	quality: number | null
+	bedtime: string | null
+	wake_time: string | null
+	notes: string | null
+	created_at: string
+}
+
+export type HabitCategory = 'positive' | 'neutral'
+
+export type HabitDefinition = {
+	id: number
+	user_id: string
+	name: string
+	icon: string | null
+	domain_id: number | null
+	category: HabitCategory
+	sort_order: number
+	is_active: boolean
+	created_at: string
+}
+
+export type HabitLog = {
+	id: number
+	user_id: string
+	habit_definition_id: number
+	date: string
+	done: boolean
+	created_at: string
+}
+
+export type TodoistTask = {
+	id: number
+	user_id: string
+	todoist_id: string
+	content: string
+	description: string | null
+	project_name: string | null
+	priority: number | null
+	due_date: string | null
+	is_completed: boolean
+	labels: string[]
+	synced_at: string
+}
+
+export type GithubItem = {
+	id: number
+	user_id: string
+	github_id: string
+	item_type: 'issue' | 'pull_request' | 'commit' | 'event'
+	repo: string
+	title: string | null
+	url: string | null
+	state: string | null
+	created_at_gh: string | null
+	synced_at: string
+}
+
+// Insert types (omit server-generated fields)
+export type LifeDomainInsert = Omit<LifeDomain, 'id' | 'user_id' | 'created_at'>
+export type ProjectInsert = Omit<Project, 'id' | 'user_id' | 'created_at'>
+export type TagInsert = Omit<Tag, 'id' | 'user_id' | 'created_at'>
+export type PomodoroSessionInsert = Omit<
+	PomodoroSession,
+	'id' | 'user_id' | 'created_at'
+>
+export type CheckInInsert = Omit<CheckIn, 'id' | 'user_id' | 'created_at'>
+export type SleepLogInsert = Omit<SleepLog, 'id' | 'user_id' | 'created_at'>
+export type HabitDefinitionInsert = Omit<
+	HabitDefinition,
+	'id' | 'user_id' | 'created_at'
+>
+export type HabitLogInsert = Omit<HabitLog, 'id' | 'user_id' | 'created_at'>


### PR DESCRIPTION
## Summary

- New `flow` Supabase schema (11 tables) with RLS: domains, projects, tags, pomodoro sessions, check-ins, sleep logs, habits, todoist/github caches
- Pomodoro timer (zustand): intention form, 15/25/50m durations, post-session mood check, break timer, persistent mini-timer in header
- Daily tracking: sleep log (hour presets + feeling emojis), habit toggles, mood/energy check-ins (6 scales)
- Dashboard with sleep debt banner, gentle work-binge reminders, today's sessions
- Domain & project management, Todoist + GitHub sync API routes, settings page
- PWA: route-scoped manifest, service worker, standalone display mode

## Test plan

- [ ] Run migration, verify tables in Supabase Studio
- [ ] Timer end-to-end: start → countdown → complete → mood check → DB
- [ ] Sleep log: tap preset, tap emoji, verify auto-save
- [ ] Check-in, habits, domains, settings all functional
- [ ] PWA: Add to Home Screen, verify standalone mode
- [ ] Mobile viewport: big tap targets work

🤖 Generated with [Claude Code](https://claude.com/claude-code)