### PR TITLE
Fix double padding on code blocks inside prose

### DIFF
--- a/components/lib/print-markdown.tsx
+++ b/components/lib/print-markdown.tsx
@@ -14,6 +14,7 @@ const PrintMarkdown = ({ markdown }: { markdown: string }) => (
 		rehypePlugins={[rehypeRaw]}
 		components={{
 			img: (props) => <LazyImage {...props} />,
+			pre: ({ children }) => <>{children}</>,
 			code: ({ className, children, ...props }) => {
 				const match = /language-(\w+)/.exec(className || '')
 				const codeString = String(children).replace(/\n$/, '')

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,9 @@ layer(base);
 	.prose img {
 		@apply shadow-lg;
 	}
+	.prose pre code {
+		@apply p-0;
+	}
 	input.copy-input,
 	form.form input:not([type='checkbox']),
 	form.form textarea {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,7 +57,7 @@ layer(base);
 	.prose img {
 		@apply shadow-lg;
 	}
-	.prose pre code {
+	.prose pre {
 		@apply p-0;
 	}
 	input.copy-input,


### PR DESCRIPTION
The Tailwind Typography plugin applies padding to both `<pre>` and nested `<code>` elements, causing double padding on syntax-highlighted code blocks. Reset padding on pre code to zero.

https://claude.ai/code/session_01PWEwnbshDmKzbMRrpVFXqv