### PR TITLE
Add options menu to post editor with delete and slug change

### DIFF
--- a/app/(private)/posts/[slug]/edit/page.tsx
+++ b/app/(private)/posts/[slug]/edit/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState, useRef, useEffect } from 'react'
 import { Tables } from '@/types/supabase'
 import { useRouter } from 'next/navigation'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
@@ -55,6 +56,103 @@ const PostEditSchema = z.object({
 
 type PostUpdate = z.infer<typeof PostEditSchema>
 
+function OptionsMenu({
+	postId,
+	slug,
+}: {
+	postId: string
+	slug: string
+}) {
+	const [open, setOpen] = useState(false)
+	const menuRef = useRef<HTMLDivElement>(null)
+	const router = useRouter()
+	const queryClient = useQueryClient()
+
+	useEffect(() => {
+		function handleClickOutside(e: MouseEvent) {
+			if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+				setOpen(false)
+			}
+		}
+		if (open) document.addEventListener('mousedown', handleClickOutside)
+		return () => document.removeEventListener('mousedown', handleClickOutside)
+	}, [open])
+
+	async function handleDelete() {
+		setOpen(false)
+		if (!confirm('Are you sure you want to delete this post? This cannot be undone.')) return
+		const { error } = await createClient()
+			.from('posts')
+			.delete()
+			.eq('id', postId)
+		if (error) {
+			alert(`Failed to delete: ${error.message}`)
+			return
+		}
+		await revalidatePost(slug)
+		queryClient.invalidateQueries({ queryKey: ['post', slug] })
+		router.push('/posts/drafts')
+	}
+
+	async function handleChangeSlug() {
+		setOpen(false)
+		const newSlug = prompt('Enter new slug:', slug)
+		if (!newSlug || newSlug === slug) return
+		if (!/^[a-z0-9][a-z0-9-_]+[a-z0-9]$/.test(newSlug)) {
+			alert('Invalid slug. Use lowercase letters, numbers, hyphens, and underscores (min 3 chars).')
+			return
+		}
+		if (!confirm(`Change slug from "${slug}" to "${newSlug}"? This will break existing links.`)) return
+		const { error } = await createClient()
+			.from('posts')
+			.update({ slug: newSlug })
+			.eq('id', postId)
+		if (error) {
+			alert(`Failed to change slug: ${error.message}`)
+			return
+		}
+		await revalidatePost(slug)
+		await revalidatePost(newSlug)
+		queryClient.invalidateQueries({ queryKey: ['post', slug] })
+		router.replace(`/posts/${newSlug}/edit`)
+	}
+
+	return (
+		<div className="relative" ref={menuRef}>
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500"
+				aria-label="Post options"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+					<circle cx="12" cy="5" r="2" />
+					<circle cx="12" cy="12" r="2" />
+					<circle cx="12" cy="19" r="2" />
+				</svg>
+			</button>
+			{open && (
+				<div className="absolute right-0 mt-1 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg z-10">
+					<button
+						type="button"
+						onClick={handleChangeSlug}
+						className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+					>
+						Change slug
+					</button>
+					<button
+						type="button"
+						onClick={handleDelete}
+						className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-gray-100 dark:hover:bg-gray-700"
+					>
+						Delete post
+					</button>
+				</div>
+			)}
+		</div>
+	)
+}
+
 function Client({ initialData }: { initialData: Tables<'posts'> }) {
 	const { session } = useSession()
 
@@ -94,7 +192,10 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 	return (
 		<>
 			<div className="col-span-2">
-				<h1 className="h3">Edit your post</h1>
+				<div className="flex justify-between items-center">
+					<h1 className="h3">Edit your post</h1>
+					<OptionsMenu postId={initialData.id} slug={initialData.slug} />
+				</div>
 				<form
 					noValidate
 					className="form flex flex-col gap-4"


### PR DESCRIPTION
## Summary
Added an options menu to the post edit page that allows users to delete posts and change post slugs with appropriate confirmations and validations.

## Key Changes
- Created new `OptionsMenu` component with a three-dot menu button that displays options when clicked
- Implemented click-outside detection to close the menu when clicking elsewhere on the page
- Added "Change slug" functionality with:
  - Slug format validation (lowercase letters, numbers, hyphens, underscores, min 3 chars)
  - Confirmation dialog before changing slug
  - Revalidation of both old and new slug paths
  - Router redirect to new slug URL after successful change
- Added "Delete post" functionality with:
  - Confirmation dialog to prevent accidental deletion
  - Error handling with user feedback
  - Automatic redirect to drafts page after deletion
  - Query cache invalidation
- Integrated the options menu into the post editor header, positioned to the right of the "Edit your post" title
- Added proper dark mode styling for the menu and button

## Implementation Details
- Used `useRef` and `useEffect` to manage click-outside behavior for menu dismissal
- Slug validation uses regex pattern: `/^[a-z0-9][a-z0-9-_]+[a-z0-9]$/`
- Both operations call `revalidatePost()` to update cached content
- Menu uses semantic HTML with proper `aria-label` for accessibility
- Styled with Tailwind CSS including hover states and dark mode support

https://claude.ai/code/session_018rbvYNfHYtdE3aAYvkaa6m