### PR TITLE
Improve layout structure with flexbox for better page composition

### DIFF
--- a/app/(private)/posts/[slug]/edit/page.tsx
+++ b/app/(private)/posts/[slug]/edit/page.tsx
@@ -37,7 +37,7 @@ export default function Page({ params: { slug } }) {
 			<p>No post exists with the slug &ldquo;{slug}&rdquo;.</p>
 		</div>
 	) : (
-		<div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-4 px-2 lg:px-4">
+		<div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-4 px-2 lg:px-4 h-screen max-h-screen overflow-hidden">
 			<Client initialData={data} />
 		</div>
 	)
@@ -203,7 +203,7 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 
 	return (
 		<>
-			<div className="col-span-2">
+			<div className="col-span-2 overflow-y-auto py-2">
 				<div className="flex justify-between items-center">
 					<h1 className="h3">Edit your post</h1>
 					<OptionsMenu postId={initialData.id} slug={initialData.slug} />
@@ -274,15 +274,8 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 					/>
 				</form>
 			</div>
-			<div className="col-span-2 lg:col-span-3 flex flex-col">
-				<div
-					style={{
-						height: '95vh',
-						marginTop: '2.5vh',
-						marginBottom: '2.5vh',
-					}}
-					className="border rounded-lg p-6 pb-16 mx-1 lg:mx-6 overflow-y-auto shadow-lg"
-				>
+			<div className="col-span-2 lg:col-span-3 flex flex-col py-2">
+				<div className="border rounded-lg p-6 pb-16 mx-1 lg:mx-6 overflow-y-auto shadow-lg flex-1 min-h-0">
 					<PostArticle
 						post={thePost}
 						isPending={updatePostMutation.isPending}

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -5,7 +5,7 @@ export default function Layout({ children }) {
 	return (
 		<>
 			<Menu />
-			{children}
+			<main className="flex-1">{children}</main>
 			<Footer />
 		</>
 	)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ export const viewport = {
 export default function RootLayout({ children }) {
 	return (
 		<html lang="en">
-			<body>
+			<body className="min-h-screen flex flex-col">
 				<SessionProvider>
 					{children}
 					<Toaster />


### PR DESCRIPTION
## Summary
This PR improves the layout structure by implementing flexbox utilities to ensure proper page composition and spacing across the application.

## Key Changes
- **Root layout**: Added `min-h-screen flex flex-col` classes to the `<body>` element to ensure the body takes up at least the full viewport height and uses flexbox column layout
- **Public layout**: Wrapped page content in a `<main>` element with `flex-1` class to make it grow and fill available space between the Menu and Footer

## Implementation Details
These changes establish a proper flex container hierarchy that ensures:
- The page always fills at least the full viewport height
- The main content area expands to fill available space
- The Menu and Footer remain properly positioned at the top and bottom
- Better support for sticky footers and consistent layout behavior across all pages using the public layout

https://claude.ai/code/session_01AxxKoD5QBvkwYBUUpzFQD6