### PR TITLE
Add sentence navigation sidebar with auto-scroll

### DIFF
--- a/app/(projects)/reader/page.tsx
+++ b/app/(projects)/reader/page.tsx
@@ -430,16 +430,6 @@ export default function RSVPReader() {
 		return () => clearTimeout(id)
 	}, [playing, wpm, words.length, idx, delays])
 
-	// Auto-scroll sidebar to keep current sentence visible
-	useEffect(() => {
-		const el = sidebarRef.current
-		if (!el) return
-		const active = el.querySelector('[data-active="true"]') as HTMLElement
-		if (active) {
-			active.scrollIntoView({ block: 'center', behavior: 'smooth' })
-		}
-	}, [currentSentenceIdx])
-
 	const startReading = useCallback(
 		(text: string, name: string) => {
 			const { words: w, delays: d, quoteDepth: q } = tokenize(text)
@@ -531,6 +521,16 @@ export default function RSVPReader() {
 	}, [idx, sentences])
 
 	const sidebarRef = useRef<HTMLDivElement>(null)
+
+	// Auto-scroll sidebar to keep current sentence visible
+	useEffect(() => {
+		const el = sidebarRef.current
+		if (!el) return
+		const active = el.querySelector('[data-active="true"]') as HTMLElement
+		if (active) {
+			active.scrollIntoView({ block: 'center', behavior: 'smooth' })
+		}
+	}, [currentSentenceIdx])
 
 	const savedList = Object.entries(savedTexts)
 		.map(([hash, data]) => ({ hash, ...data }))

--- a/app/(projects)/reader/page.tsx
+++ b/app/(projects)/reader/page.tsx
@@ -9,6 +9,8 @@ import {
 	type ChangeEvent,
 	type DragEvent,
 } from 'react'
+import { getORP, hasLongNumber, tokenize } from './tokenizer'
+import type { ORPParts } from './tokenizer'
 
 declare global {
 	interface Window {
@@ -65,12 +67,6 @@ const LS_FONT_KEY = 'rsvp-font'
 
 type Screen = 'input' | 'read'
 
-interface ORPParts {
-	before: string
-	orp: string
-	after: string
-}
-
 interface SavedPosition {
 	name: string
 	idx: number
@@ -80,124 +76,6 @@ interface SavedPosition {
 }
 
 type SavedPositions = Record<string, SavedPosition>
-
-function getORP(word: string): ORPParts {
-	if (!word) return { before: '', orp: '', after: '' }
-	const len = word.length
-	let pos: number
-	if (len <= 1) pos = 0
-	else if (len <= 5) pos = 1
-	else if (len <= 9) pos = 2
-	else if (len <= 13) pos = 3
-	else pos = Math.floor(len * 0.28)
-	return {
-		before: word.slice(0, pos),
-		orp: word[pos],
-		after: word.slice(pos + 1),
-	}
-}
-
-/** A word is a "long number" if it contains 4+ digit characters total */
-function hasLongNumber(word: string): boolean {
-	const digitCount = (word.match(/\d/g) || []).length
-	return digitCount >= 4
-}
-
-/**
- * Tokenize text into words with per-word delay multipliers.
- *
- * Delays: comma → 1.3x, period/semicolon/!/? → 1.8x, paragraph → 4x,
- * long numbers (4+ digits, incl. "1,000,000" or "3:00:51.25") → 2x.
- * Em-dashes are joined to the preceding word.
- * No paragraph pause if it ends with ':' or next starts with '>'.
- */
-function tokenize(text: string): {
-	words: string[]
-	delays: number[]
-	quoteDepth: number[]
-} {
-	const paragraphs = text.split(/\n\s*\n/)
-	const words: string[] = []
-	const delays: number[] = []
-	const quoteDepth: number[] = []
-	let depth = 0
-
-	for (let p = 0; p < paragraphs.length; p++) {
-		const rawWords = paragraphs[p].split(/\s+/).filter((w) => w.length > 0)
-		if (rawWords.length === 0) continue
-
-		// Dashes (em-dash, en-dash, double-hyphen) attach to the previous word
-		// as a suffix but never grab the next word.
-		// Standalone dots (from spaced ellipsis like ". . .") also attach.
-		const paraWords: string[] = []
-		const isDash = (s: string) => s === '—' || s === '–' || s === '--'
-		const startsDash = (s: string) =>
-			s.startsWith('—') || s.startsWith('–') || s.startsWith('--')
-		const isDot = (s: string) => s === '.' || s === '..'
-		for (let i = 0; i < rawWords.length; i++) {
-			const w = rawWords[i]
-			if (isDash(w) && paraWords.length > 0) {
-				paraWords[paraWords.length - 1] += w
-			} else if (startsDash(w) && paraWords.length > 0) {
-				paraWords[paraWords.length - 1] += w
-			} else if (isDot(w) && paraWords.length > 0) {
-				paraWords[paraWords.length - 1] += w
-			} else {
-				paraWords.push(w)
-			}
-		}
-
-		// Split on slashes: "amazing/excellent" -> "amazing/" + "/excellent"
-		const slashSplit: string[] = []
-		for (const w of paraWords) {
-			// Only split if slash is between word chars (not URLs like http://)
-			const parts = w.split(/(?<=\w)\/(?=\w)/)
-			if (parts.length > 1) {
-				for (let j = 0; j < parts.length; j++) {
-					const prefix = j > 0 ? '/' : ''
-					const suffix = j < parts.length - 1 ? '/' : ''
-					slashSplit.push(prefix + parts[j] + suffix)
-				}
-			} else {
-				slashSplit.push(w)
-			}
-		}
-
-		for (const w of slashSplit) {
-			// Count opening quotes at the start of the word
-			const opens = (w.match(/^[""'«]+/) || [''])[0].length
-			// Count closing quotes at the end of the word
-			const closes = (w.match(/[""'»]+$/) || [''])[0].length
-
-			depth += opens
-			words.push(w)
-			quoteDepth.push(depth)
-			depth = Math.max(0, depth - closes)
-
-			let d = 1
-			const stripped = w.replace(/[)}\]"'»]+$/, '')
-			if (/\.{2,}$/.test(stripped) || /…$/.test(stripped)) d = 2.5
-			else if (/[.!?]$/.test(stripped)) d = 1.8
-			else if (/[,;]$/.test(stripped)) d = 1.3
-			if (hasLongNumber(w)) d = Math.max(d, 2)
-
-			delays.push(d)
-		}
-
-		if (p < paragraphs.length - 1 && words.length > 0) {
-			const lastWord = slashSplit[slashSplit.length - 1]
-			const nextPara = paragraphs[p + 1]?.trim() || ''
-			const endsWithColon = lastWord.endsWith(':')
-			const nextIsBlockquote = nextPara.startsWith('>')
-
-			if (!endsWithColon && !nextIsBlockquote) {
-				delays[delays.length - 1] = Math.max(delays[delays.length - 1], 4)
-			}
-		}
-	}
-
-	return { words, delays, quoteDepth }
-}
 
 function hashText(words: string[]): string {
 	const sample = words.slice(0, 100).join(' ')

--- a/app/(projects)/reader/page.tsx
+++ b/app/(projects)/reader/page.tsx
@@ -143,7 +143,23 @@ function tokenize(text: string): {
 			}
 		}
 
+		// Split on slashes: "amazing/excellent" -> "amazing/" + "/excellent"
+		const slashSplit: string[] = []
 		for (const w of paraWords) {
+			// Only split if slash is between word chars (not URLs like http://)
+			const parts = w.split(/(?<=\w)\/(?=\w)/)
+			if (parts.length > 1) {
+				for (let j = 0; j < parts.length; j++) {
+					const prefix = j > 0 ? '/' : ''
+					const suffix = j < parts.length - 1 ? '/' : ''
+					slashSplit.push(prefix + parts[j] + suffix)
+				}
+			} else {
+				slashSplit.push(w)
+			}
+		}
+
+		for (const w of slashSplit) {
 			// Count opening quotes at the start of the word
 			const opens = (w.match(/^[""'«]+/) || [''])[0].length
 			// Count closing quotes at the end of the word
@@ -983,14 +999,14 @@ export default function RSVPReader() {
 					{/* Ghost quotes when inside a quotation */}
 					{inQuote && !wordOpensQuote && (
 						<div
-							className={`absolute ${c.textFaint} pointer-events-none select-none`}
+							className={`absolute ${c.textMuted} pointer-events-none select-none`}
 							style={{
 								left: '1.5rem',
 								top: '50%',
 								transform: 'translateY(-50%)',
-								fontSize: 'clamp(1.5rem, 3.5vw, 2.5rem)',
+								fontSize: 'clamp(2rem, 4.5vw, 3.5rem)',
 								fontFamily: fc.family,
-								opacity: 0.3,
+								opacity: 0.5,
 							}}
 						>
 							&ldquo;
@@ -998,14 +1014,14 @@ export default function RSVPReader() {
 					)}
 					{inQuote && !wordClosesQuote && (
 						<div
-							className={`absolute ${c.textFaint} pointer-events-none select-none`}
+							className={`absolute ${c.textMuted} pointer-events-none select-none`}
 							style={{
 								right: '1.5rem',
 								top: '50%',
 								transform: 'translateY(-50%)',
-								fontSize: 'clamp(1.5rem, 3.5vw, 2.5rem)',
+								fontSize: 'clamp(2rem, 4.5vw, 3.5rem)',
 								fontFamily: fc.family,
-								opacity: 0.3,
+								opacity: 0.5,
 							}}
 						>
 							&rdquo;

--- a/app/(projects)/reader/page.tsx
+++ b/app/(projects)/reader/page.tsx
@@ -128,15 +128,19 @@ function tokenize(text: string): {
 
 		// Dashes (em-dash, en-dash, double-hyphen) attach to the previous word
 		// as a suffix but never grab the next word.
+		// Standalone dots (from spaced ellipsis like ". . .") also attach.
 		const paraWords: string[] = []
 		const isDash = (s: string) => s === '—' || s === '–' || s === '--'
 		const startsDash = (s: string) =>
 			s.startsWith('—') || s.startsWith('–') || s.startsWith('--')
+		const isDot = (s: string) => s === '.' || s === '..'
 		for (let i = 0; i < rawWords.length; i++) {
 			const w = rawWords[i]
 			if (isDash(w) && paraWords.length > 0) {
 				paraWords[paraWords.length - 1] += w
 			} else if (startsDash(w) && paraWords.length > 0) {
+				paraWords[paraWords.length - 1] += w
+			} else if (isDot(w) && paraWords.length > 0) {
 				paraWords[paraWords.length - 1] += w
 			} else {
 				paraWords.push(w)
@@ -172,7 +176,8 @@ function tokenize(text: string): {
 
 			let d = 1
 			const stripped = w.replace(/[)}\]"'»]+$/, '')
-			if (/[.!?]$/.test(stripped)) d = 1.8
+			if (/\.{2,}$/.test(stripped) || /…$/.test(stripped)) d = 2.5
+			else if (/[.!?]$/.test(stripped)) d = 1.8
 			else if (/[,;]$/.test(stripped)) d = 1.3
 			if (hasLongNumber(w)) d = Math.max(d, 2)
 
@@ -180,7 +185,7 @@ function tokenize(text: string): {
 		}
 
 		if (p < paragraphs.length - 1 && words.length > 0) {
-			const lastWord = paraWords[paraWords.length - 1]
+			const lastWord = slashSplit[slashSplit.length - 1]
 			const nextPara = paragraphs[p + 1]?.trim() || ''
 			const endsWithColon = lastWord.endsWith(':')
 			const nextIsBlockquote = nextPara.startsWith('>')

--- a/app/(projects)/reader/page.tsx
+++ b/app/(projects)/reader/page.tsx
@@ -5,6 +5,7 @@ import {
 	useEffect,
 	useRef,
 	useCallback,
+	useMemo,
 	type ChangeEvent,
 	type DragEvent,
 } from 'react'
@@ -429,6 +430,16 @@ export default function RSVPReader() {
 		return () => clearTimeout(id)
 	}, [playing, wpm, words.length, idx, delays])
 
+	// Auto-scroll sidebar to keep current sentence visible
+	useEffect(() => {
+		const el = sidebarRef.current
+		if (!el) return
+		const active = el.querySelector('[data-active="true"]') as HTMLElement
+		if (active) {
+			active.scrollIntoView({ block: 'center', behavior: 'smooth' })
+		}
+	}, [currentSentenceIdx])
+
 	const startReading = useCallback(
 		(text: string, name: string) => {
 			const { words: w, delays: d, quoteDepth: q } = tokenize(text)
@@ -495,6 +506,31 @@ export default function RSVPReader() {
 	const ctxEnd = Math.min(words.length, idx + 80)
 	const ctxWords = words.slice(ctxStart, ctxEnd)
 	const ctxLocal = idx - ctxStart
+
+	// Compute sentence boundaries for sidebar navigation
+	const sentences = useMemo(() => {
+		if (words.length === 0) return []
+		const result: { start: number; preview: string }[] = []
+		let sentStart = 0
+		for (let i = 0; i < words.length; i++) {
+			// Sentence ends at punctuation (delay >= 1.8) or paragraph break (delay >= 4)
+			if (delays[i] >= 1.8 || i === words.length - 1) {
+				const preview = words.slice(sentStart, Math.min(sentStart + 8, i + 1)).join(' ')
+				result.push({ start: sentStart, preview })
+				sentStart = i + 1
+			}
+		}
+		return result
+	}, [words, delays])
+
+	const currentSentenceIdx = useMemo(() => {
+		for (let i = sentences.length - 1; i >= 0; i--) {
+			if (idx >= sentences[i].start) return i
+		}
+		return 0
+	}, [idx, sentences])
+
+	const sidebarRef = useRef<HTMLDivElement>(null)
 
 	const savedList = Object.entries(savedTexts)
 		.map(([hash, data]) => ({ hash, ...data }))
@@ -968,26 +1004,38 @@ export default function RSVPReader() {
 				)}
 			</div>
 
-			{/* Right panel: context */}
-			<div className={`border-l ${c.border} p-5 flex flex-col overflow-hidden`}>
-				<p className="text-[9px] tracking-[0.35em] text-amber-600 uppercase mb-5">
-					Context
+			{/* Right panel: sentence navigation */}
+			<div className={`border-l ${c.border} p-3 flex flex-col overflow-hidden`}>
+				<p className="text-[9px] tracking-[0.35em] text-amber-600 uppercase mb-3">
+					Sentences
 				</p>
-				<div className="text-xs leading-loose overflow-hidden flex-1">
-					{ctxWords.map((w, i) => (
-						<span
-							key={ctxStart + i}
-							className={`mr-1 transition-colors duration-100 ${
-								i === ctxLocal
-									? c.ctxCurrent
-									: i < ctxLocal
-										? c.ctxPast
-										: c.ctxFuture
-							}`}
-						>
-							{w}
-						</span>
-					))}
+				<div
+					ref={sidebarRef}
+					className="overflow-y-auto flex-1 space-y-0.5"
+				>
+					{sentences.map((s, i) => {
+						const isCurrent = i === currentSentenceIdx
+						const isPast = i < currentSentenceIdx
+						return (
+							<button
+								key={s.start}
+								data-active={isCurrent}
+								onClick={() => {
+									setIdx(s.start)
+									setPlaying(false)
+								}}
+								className={`block w-full text-left text-[11px] leading-snug px-2 py-1 rounded truncate transition-colors cursor-pointer ${
+									isCurrent
+										? `${c.ctxCurrent} ${dark ? 'bg-gray-800' : 'bg-sky-100'}`
+										: isPast
+											? c.ctxPast
+											: c.ctxFuture
+								} ${dark ? 'hover:bg-gray-800' : 'hover:bg-sky-100'}`}
+							>
+								{s.preview}
+							</button>
+						)
+					})}
 				</div>
 			</div>
 

--- a/app/(projects)/reader/page.tsx
+++ b/app/(projects)/reader/page.tsx
@@ -500,13 +500,16 @@ export default function RSVPReader() {
 	// Compute sentence boundaries for sidebar navigation
 	const sentences = useMemo(() => {
 		if (words.length === 0) return []
-		const result: { start: number; preview: string }[] = []
+		const result: { start: number; preview: string; paraStart: boolean }[] = []
 		let sentStart = 0
+		let nextIsParaStart = true // first sentence starts a paragraph
 		for (let i = 0; i < words.length; i++) {
 			// Sentence ends at punctuation (delay >= 1.8) or paragraph break (delay >= 4)
 			if (delays[i] >= 1.8 || i === words.length - 1) {
 				const preview = words.slice(sentStart, Math.min(sentStart + 8, i + 1)).join(' ')
-				result.push({ start: sentStart, preview })
+				result.push({ start: sentStart, preview, paraStart: nextIsParaStart })
+				// If this word ends a paragraph (delay >= 4), the next sentence starts a new one
+				nextIsParaStart = delays[i] >= 4
 				sentStart = i + 1
 			}
 		}
@@ -1025,6 +1028,8 @@ export default function RSVPReader() {
 									setPlaying(false)
 								}}
 								className={`block w-full text-left text-[11px] leading-snug px-2 py-1 rounded truncate transition-colors cursor-pointer ${
+									s.paraStart && i > 0 ? 'mt-3' : ''
+								} ${
 									isCurrent
 										? `${c.ctxCurrent} ${dark ? 'bg-gray-800' : 'bg-sky-100'}`
 										: isPast

--- a/app/(projects)/reader/page.tsx
+++ b/app/(projects)/reader/page.tsx
@@ -59,6 +59,7 @@ const FONT_CONFIG: Record<
 }
 
 const LS_KEY = 'rsvp-reading-positions'
+const LS_TEXT_KEY = 'rsvp-texts'
 const LS_THEME_KEY = 'rsvp-theme'
 const LS_FONT_KEY = 'rsvp-font'
 
@@ -204,6 +205,33 @@ function savePosition(
 	const all = loadPositions()
 	all[hash] = { name, idx, wpm, wordCount, updatedAt: Date.now() }
 	localStorage.setItem(LS_KEY, JSON.stringify(all))
+}
+
+function saveText(hash: string, text: string) {
+	try {
+		const all = JSON.parse(localStorage.getItem(LS_TEXT_KEY) || '{}')
+		all[hash] = text
+		localStorage.setItem(LS_TEXT_KEY, JSON.stringify(all))
+	} catch {
+		// Storage full — silently skip
+	}
+}
+
+function loadText(hash: string): string | null {
+	try {
+		const all = JSON.parse(localStorage.getItem(LS_TEXT_KEY) || '{}')
+		return all[hash] || null
+	} catch {
+		return null
+	}
+}
+
+function deleteText(hash: string) {
+	try {
+		const all = JSON.parse(localStorage.getItem(LS_TEXT_KEY) || '{}')
+		delete all[hash]
+		localStorage.setItem(LS_TEXT_KEY, JSON.stringify(all))
+	} catch {}
 }
 
 function loadTheme(): 'light' | 'dark' {
@@ -453,6 +481,7 @@ export default function RSVPReader() {
 			}
 
 			savePosition(hash, name, saved?.idx || 0, saved?.wpm || wpm, w.length)
+			saveText(hash, text)
 			setSavedTexts(loadPositions())
 		},
 		[wpm],
@@ -773,23 +802,38 @@ export default function RSVPReader() {
 								Continue Reading
 							</p>
 							<div className="flex flex-col gap-2">
-								{savedList.map((s) => (
-									<div
-										key={s.hash}
-										className={`${c.cardBg} border ${c.inputBorder} rounded-lg px-4 py-3 text-sm flex items-center gap-3`}
-									>
-										<div className="flex-1 min-w-0">
-											<p className="font-medium truncate">{s.name}</p>
-											<p className={`${c.textMuted} text-xs`}>
-												{Math.round((s.idx / s.wordCount) * 100)}% ·{' '}
-												{s.wordCount.toLocaleString()} words · {s.wpm} wpm
-											</p>
+								{savedList.map((s) => {
+									const hasText = !!loadText(s.hash)
+									return (
+										<div
+											key={s.hash}
+											className={`${c.cardBg} border ${c.inputBorder} rounded-lg px-4 py-3 text-sm flex items-center gap-3`}
+										>
+											<div className="flex-1 min-w-0">
+												<p className="font-medium truncate">{s.name}</p>
+												<p className={`${c.textMuted} text-xs`}>
+													{Math.round((s.idx / s.wordCount) * 100)}% ·{' '}
+													{s.wordCount.toLocaleString()} words · {s.wpm} wpm
+												</p>
+											</div>
+											{hasText ? (
+												<button
+													onClick={() => {
+														const text = loadText(s.hash)
+														if (text) startReading(text, s.name)
+													}}
+													className={`${c.btnText} ${c.btnHoverText} text-xs shrink-0 cursor-pointer`}
+												>
+													Resume →
+												</button>
+											) : (
+												<p className={`${c.textFaint} text-xs shrink-0`}>
+													Re-upload to resume →
+												</p>
+											)}
 										</div>
-										<p className={`${c.textFaint} text-xs shrink-0`}>
-											Re-upload to resume →
-										</p>
-									</div>
-								))}
+									)
+								})}
 							</div>
 						</div>
 					)}

--- a/app/(projects)/reader/tokenizer.test.ts
+++ b/app/(projects)/reader/tokenizer.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import { getORP, hasLongNumber, tokenize } from './tokenizer'
+
+describe('getORP', () => {
+	it('handles empty string', () => {
+		expect(getORP('')).toEqual({ before: '', orp: '', after: '' })
+	})
+
+	it('single character word', () => {
+		expect(getORP('a')).toEqual({ before: '', orp: 'a', after: '' })
+	})
+
+	it('short word (2-5 chars) has ORP at index 1', () => {
+		const r = getORP('hello')
+		expect(r).toEqual({ before: 'h', orp: 'e', after: 'llo' })
+	})
+
+	it('medium word (6-9 chars) has ORP at index 2', () => {
+		const r = getORP('amazing')
+		expect(r).toEqual({ before: 'am', orp: 'a', after: 'zing' })
+	})
+
+	it('longer word (10-13 chars) has ORP at index 3', () => {
+		const r = getORP('outstanding')
+		expect(r).toEqual({ before: 'out', orp: 's', after: 'tanding' })
+	})
+})
+
+describe('hasLongNumber', () => {
+	it('returns false for regular words', () => {
+		expect(hasLongNumber('hello')).toBe(false)
+	})
+
+	it('returns false for short numbers', () => {
+		expect(hasLongNumber('123')).toBe(false)
+	})
+
+	it('returns true for 4+ digit numbers', () => {
+		expect(hasLongNumber('1234')).toBe(true)
+		expect(hasLongNumber('1,000,000')).toBe(true)
+	})
+
+	it('returns true for time-like numbers', () => {
+		expect(hasLongNumber('3:00:51.25')).toBe(true)
+	})
+})
+
+describe('tokenize', () => {
+	describe('basic splitting', () => {
+		it('splits text into words', () => {
+			const { words } = tokenize('hello world')
+			expect(words).toEqual(['hello', 'world'])
+		})
+
+		it('handles multiple spaces', () => {
+			const { words } = tokenize('hello   world')
+			expect(words).toEqual(['hello', 'world'])
+		})
+	})
+
+	describe('delays', () => {
+		it('assigns base delay of 1 for normal words', () => {
+			const { delays } = tokenize('hello world')
+			expect(delays).toEqual([1, 1])
+		})
+
+		it('assigns 1.8x delay after sentence-ending punctuation', () => {
+			const { delays } = tokenize('end. start')
+			expect(delays[0]).toBe(1.8)
+		})
+
+		it('assigns 1.3x delay after comma', () => {
+			const { delays } = tokenize('first, second')
+			expect(delays[0]).toBe(1.3)
+		})
+
+		it('assigns 1.3x delay after semicolon', () => {
+			const { delays } = tokenize('first; second')
+			expect(delays[0]).toBe(1.3)
+		})
+
+		it('assigns 2.5x delay after ellipsis (three dots)', () => {
+			const { delays } = tokenize('wait... okay')
+			expect(delays[0]).toBe(2.5)
+		})
+
+		it('assigns 2.5x delay after unicode ellipsis', () => {
+			const { delays } = tokenize('wait\u2026 okay')
+			expect(delays[0]).toBe(2.5)
+		})
+
+		it('assigns 2x delay for long numbers', () => {
+			const { delays } = tokenize('call 1234 now')
+			expect(delays[1]).toBe(2)
+		})
+
+		it('assigns paragraph delay of 4x', () => {
+			const { delays } = tokenize('end.\n\nStart')
+			expect(delays[0]).toBe(4)
+		})
+
+		it('no paragraph delay when ending with colon', () => {
+			const { delays } = tokenize('items:\n\nfirst')
+			expect(delays[0]).toBe(1)
+		})
+	})
+
+	describe('dash handling', () => {
+		it('attaches standalone em-dash to previous word', () => {
+			const { words } = tokenize('hello \u2014 world')
+			expect(words).toEqual(['hello\u2014', 'world'])
+		})
+
+		it('attaches standalone en-dash to previous word', () => {
+			const { words } = tokenize('hello \u2013 world')
+			expect(words).toEqual(['hello\u2013', 'world'])
+		})
+
+		it('attaches word starting with em-dash to previous word', () => {
+			const { words } = tokenize('hello \u2014world')
+			expect(words).toEqual(['hello\u2014world'])
+		})
+	})
+
+	describe('ellipsis dot reattachment', () => {
+		it('attaches standalone dots to previous word', () => {
+			const { words } = tokenize('wait . . . okay')
+			expect(words).toEqual(['wait...', 'okay'])
+		})
+
+		it('does not attach dot as first word', () => {
+			const { words } = tokenize('. hello')
+			expect(words).toEqual(['.', 'hello'])
+		})
+	})
+
+	describe('slash splitting', () => {
+		it('splits word on slash with slash visible on both sides', () => {
+			const { words } = tokenize('amazing/excellent')
+			expect(words).toEqual(['amazing/', '/excellent'])
+		})
+
+		it('handles multiple slashes', () => {
+			const { words } = tokenize('a/b/c')
+			expect(words).toEqual(['a/', '/b/', '/c'])
+		})
+
+		it('does not split URL-like patterns', () => {
+			// http:// has slash after colon, not between word chars
+			const { words } = tokenize('http://example')
+			expect(words).toEqual(['http://example'])
+		})
+	})
+
+	describe('quote depth tracking', () => {
+		it('tracks opening smart quotes', () => {
+			const { quoteDepth } = tokenize('\u201chello world\u201d')
+			expect(quoteDepth).toEqual([1, 1])
+		})
+
+		it('returns to depth 0 after closing quote', () => {
+			const { quoteDepth } = tokenize('\u201chello\u201d world')
+			expect(quoteDepth).toEqual([1, 0])
+		})
+
+		it('resets quote depth at paragraph boundary', () => {
+			const { quoteDepth } = tokenize('\u201chello\n\nworld')
+			// First paragraph: "hello opens depth to 1
+			// Second paragraph: depth resets to 0
+			expect(quoteDepth).toEqual([1, 0])
+		})
+
+		it('unbalanced opening quote does not leak across paragraphs', () => {
+			const { quoteDepth } = tokenize(
+				'\u201cstart of quote\n\nnext paragraph here\n\nthird paragraph too',
+			)
+			// First paragraph words at depth 1
+			expect(quoteDepth[0]).toBe(1) // "start
+			expect(quoteDepth[1]).toBe(1) // of
+			expect(quoteDepth[2]).toBe(1) // quote
+			// Second paragraph resets
+			expect(quoteDepth[3]).toBe(0) // next
+			expect(quoteDepth[4]).toBe(0) // paragraph
+			expect(quoteDepth[5]).toBe(0) // here
+			// Third paragraph also at 0
+			expect(quoteDepth[6]).toBe(0)
+		})
+
+		it('tracks nested quotes', () => {
+			const { quoteDepth } = tokenize('\u201c\u2018inner\u2019\u201d')
+			expect(quoteDepth).toEqual([2])
+		})
+
+		it('handles balanced quotes within a paragraph', () => {
+			const { quoteDepth } = tokenize(
+				'she said \u201chello\u201d and left',
+			)
+			// she=0, said=0, \u201chello\u201d=1, and=0, left=0
+			expect(quoteDepth).toEqual([0, 0, 1, 0, 0])
+		})
+	})
+})

--- a/app/(projects)/reader/tokenizer.ts
+++ b/app/(projects)/reader/tokenizer.ts
@@ -1,0 +1,132 @@
+export interface ORPParts {
+	before: string
+	orp: string
+	after: string
+}
+
+export function getORP(word: string): ORPParts {
+	if (!word) return { before: '', orp: '', after: '' }
+	const len = word.length
+	let pos: number
+	if (len <= 1) pos = 0
+	else if (len <= 5) pos = 1
+	else if (len <= 9) pos = 2
+	else if (len <= 13) pos = 3
+	else pos = Math.floor(len * 0.28)
+	return {
+		before: word.slice(0, pos),
+		orp: word[pos],
+		after: word.slice(pos + 1),
+	}
+}
+
+/** A word is a "long number" if it contains 4+ digit characters total */
+export function hasLongNumber(word: string): boolean {
+	const digitCount = (word.match(/\d/g) || []).length
+	return digitCount >= 4
+}
+
+/**
+ * Tokenize text into words with per-word delay multipliers.
+ *
+ * Delays: comma → 1.3x, period/semicolon/!/? → 1.8x, ellipsis → 2.5x,
+ * paragraph → 4x, long numbers (4+ digits) → 2x.
+ * Em-dashes are joined to the preceding word.
+ * Slashes split into two words with the slash visible on both sides.
+ * No paragraph pause if it ends with ':' or next starts with '>'.
+ *
+ * Quote depth resets at paragraph boundaries to avoid false positives
+ * from unbalanced quotes in extracted text.
+ */
+export function tokenize(text: string): {
+	words: string[]
+	delays: number[]
+	quoteDepth: number[]
+} {
+	const paragraphs = text.split(/\n\s*\n/)
+	const words: string[] = []
+	const delays: number[] = []
+	const quoteDepth: number[] = []
+	let depth = 0
+
+	for (let p = 0; p < paragraphs.length; p++) {
+		const rawWords = paragraphs[p].split(/\s+/).filter((w) => w.length > 0)
+		if (rawWords.length === 0) continue
+
+		// Reset quote depth at paragraph boundaries — real quotes almost
+		// always close within the same paragraph. Unbalanced quotes from
+		// OCR or text extraction would otherwise taint everything that follows.
+		depth = 0
+
+		// Dashes (em-dash, en-dash, double-hyphen) attach to the previous word
+		// as a suffix but never grab the next word.
+		// Standalone dots (from spaced ellipsis like ". . .") also attach.
+		const paraWords: string[] = []
+		const isDash = (s: string) => s === '—' || s === '–' || s === '--'
+		const startsDash = (s: string) =>
+			s.startsWith('—') || s.startsWith('–') || s.startsWith('--')
+		const isDot = (s: string) => s === '.' || s === '..'
+		for (let i = 0; i < rawWords.length; i++) {
+			const w = rawWords[i]
+			if (isDash(w) && paraWords.length > 0) {
+				paraWords[paraWords.length - 1] += w
+			} else if (startsDash(w) && paraWords.length > 0) {
+				paraWords[paraWords.length - 1] += w
+			} else if (isDot(w) && paraWords.length > 0) {
+				paraWords[paraWords.length - 1] += w
+			} else {
+				paraWords.push(w)
+			}
+		}
+
+		// Split on slashes: "amazing/excellent" -> "amazing/" + "/excellent"
+		const slashSplit: string[] = []
+		for (const w of paraWords) {
+			// Only split if slash is between word chars (not URLs like http://)
+			const parts = w.split(/(?<=\w)\/(?=\w)/)
+			if (parts.length > 1) {
+				for (let j = 0; j < parts.length; j++) {
+					const prefix = j > 0 ? '/' : ''
+					const suffix = j < parts.length - 1 ? '/' : ''
+					slashSplit.push(prefix + parts[j] + suffix)
+				}
+			} else {
+				slashSplit.push(w)
+			}
+		}
+
+		for (const w of slashSplit) {
+			// Count opening quotes at the start of the word
+			const opens = (w.match(/^[\u201c\u201d\u2018\u00ab]+/) || [''])[0].length
+			// Count closing quotes at the end of the word
+			const closes = (w.match(/[\u201c\u201d\u2019\u00bb]+$/) || [''])[0].length
+
+			depth += opens
+			words.push(w)
+			quoteDepth.push(depth)
+			depth = Math.max(0, depth - closes)
+
+			let d = 1
+			const stripped = w.replace(/[)}\]\u201c\u201d\u2019\u00bb]+$/, '')
+			if (/\.{2,}$/.test(stripped) || /\u2026$/.test(stripped)) d = 2.5
+			else if (/[.!?]$/.test(stripped)) d = 1.8
+			else if (/[,;]$/.test(stripped)) d = 1.3
+			if (hasLongNumber(w)) d = Math.max(d, 2)
+
+			delays.push(d)
+		}
+
+		if (p < paragraphs.length - 1 && words.length > 0) {
+			const lastWord = slashSplit[slashSplit.length - 1]
+			const nextPara = paragraphs[p + 1]?.trim() || ''
+			const endsWithColon = lastWord.endsWith(':')
+			const nextIsBlockquote = nextPara.startsWith('>')
+
+			if (!endsWithColon && !nextIsBlockquote) {
+				delays[delays.length - 1] = Math.max(delays[delays.length - 1], 4)
+			}
+		}
+	}
+
+	return { words, delays, quoteDepth }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"seeds:auth": "supabase db dump --data-only --schema auth --local > ./supabase/seeds/auth.sql",
 		"seeds:public": "supabase db dump --data-only --schema public --local > ./supabase/seeds/public.sql",
 		"seeds:apply": "supabase db reset",
+		"test": "vitest run",
 		"prepare": "husky install || true"
 	},
 	"dependencies": {
@@ -53,7 +54,8 @@
 		"supabase": "^2.34.3",
 		"tailwind-merge": "^2.6.0",
 		"tailwindcss": "4.1.8",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"vitest": "^4.1.0"
 	},
 	"packageManager": "pnpm@10.14.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@22.15.24)(vite@8.0.0(@types/node@22.15.24)(jiti@2.4.2))
 
 packages:
 
@@ -131,11 +134,20 @@ packages:
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
 
+  '@emnapi/core@1.9.0':
+    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
 
+  '@emnapi/runtime@1.9.0':
+    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -223,11 +235,17 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@napi-rs/wasm-runtime@0.2.10':
     resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@next/env@14.2.29':
     resolution: {integrity: sha512-UzgLR2eBfhKIQt0aJ7PWH7XRPYw7SXz0Fpzdl5THjUnvxy4kfBk9OU4RNPNiETewEEtaBcExNFNn1QWH8wQTjg==}
@@ -305,6 +323,13 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/runtime@0.115.0':
+    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -312,6 +337,98 @@ packages:
   '@pkgr/core@0.2.4':
     resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.9':
+    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -339,6 +456,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -484,11 +604,20 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -677,6 +806,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -748,6 +906,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -821,6 +983,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -868,6 +1034,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -993,6 +1162,9 @@ packages:
   es-iterator-helpers@1.2.1:
     resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1157,9 +1329,16 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1185,6 +1364,15 @@ packages:
 
   fdir@6.4.5:
     resolution: {integrity: sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1229,6 +1417,11 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1563,8 +1756,20 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -1575,8 +1780,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.1:
     resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -1587,8 +1804,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.1:
     resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -1599,8 +1828,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -1611,8 +1852,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -1623,8 +1876,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.1:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   locate-path@6.0.0:
@@ -1652,6 +1915,9 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -1907,6 +2173,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -1954,6 +2223,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1963,6 +2235,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   possible-typed-array-names@1.1.0:
@@ -1979,6 +2255,10 @@ packages:
 
   postcss@8.5.4:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2103,6 +2383,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.9:
+    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2169,6 +2454,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2182,6 +2470,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2297,9 +2591,24 @@ packages:
   timeago.js@4.0.2:
     resolution: {integrity: sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2407,6 +2716,84 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.0:
+    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.31
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -2433,6 +2820,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2506,12 +2898,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.0.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2603,6 +3011,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -2613,6 +3023,13 @@ snapshots:
       '@emnapi/core': 1.4.3
       '@emnapi/runtime': 1.4.3
       '@tybys/wasm-util': 0.9.0
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
+      '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@next/env@14.2.29': {}
@@ -2662,10 +3079,63 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oxc-project/runtime@0.115.0': {}
+
+  '@oxc-project/types@0.115.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@pkgr/core@0.2.4': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -2703,6 +3173,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -2851,14 +3323,26 @@ snapshots:
       '@tanstack/query-core': 5.83.0
       react: 18.3.1
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -3048,6 +3532,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.7.8':
     optional: true
 
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@22.15.24)(jiti@2.4.2))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.0(@types/node@22.15.24)(jiti@2.4.2)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3142,6 +3667,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -3210,6 +3737,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3244,6 +3773,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
 
@@ -3419,6 +3950,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -3657,7 +4190,13 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -3684,6 +4223,10 @@ snapshots:
   fdir@6.4.5(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fetch-blob@3.2.0:
     dependencies:
@@ -3730,6 +4273,9 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -4133,34 +4679,67 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.1:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.1:
@@ -4177,6 +4756,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.1
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   locate-path@6.0.0:
     dependencies:
@@ -4199,6 +4794,10 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-table@3.0.4: {}
 
@@ -4664,6 +5263,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@4.3.4:
@@ -4724,11 +5325,15 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -4744,6 +5349,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.4:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -4906,6 +5517,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0-rc.9:
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.9
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5004,6 +5636,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
@@ -5011,6 +5645,10 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5149,10 +5787,21 @@ snapshots:
 
   timeago.js@4.0.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.5(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -5307,6 +5956,46 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.0(@types/node@22.15.24)(jiti@2.4.2):
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.15.24
+      fsevents: 2.3.3
+      jiti: 2.4.2
+
+  vitest@4.1.0(@types/node@22.15.24)(vite@8.0.0(@types/node@22.15.24)(jiti@2.4.2)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@22.15.24)(jiti@2.4.2))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.0(@types/node@22.15.24)(jiti@2.4.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.24
+    transitivePeerDependencies:
+      - msw
+
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
@@ -5355,6 +6044,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		include: ['**/*.test.ts'],
+	},
+	resolve: {
+		alias: {
+			'@': '.',
+		},
+	},
+})


### PR DESCRIPTION
## Summary

- **Sentence-based sidebar navigation** — Replaced the old word-level context sidebar with a clickable sentence list. Each sentence shows a preview and highlights the active one, making it easy to scan through and jump to any part of the text.
- **Paragraph breaks in sidebar** — Visual paragraph separators in the sidebar so the text structure is scannable at a glance.
- **Persistent reading state** — Book text is now saved to localStorage, so your reading position and content survive page refreshes.
- **Smarter tokenization:**
  - Em-dashes/en-dashes attach to the preceding word instead of flashing alone
  - Slashes split into two words with the slash visible on both sides (`"amazing/excellent"` → `"amazing/"` `"/excellent"`)
  - Spaced ellipsis dots (`. . .`) reattach to the previous word instead of flashing individually
  - Ellipsis gets a longer pause (2.5x) for dramatic effect
- **Quote depth indicators** — Ghost `"` `"` marks appear when reading inside a quotation, now at visible opacity/size
- **Quote depth paragraph reset** — Fixes the bug where unbalanced quotes (common in OCR/epub text) would mark an entire book as "inside a quote"
- **Extracted tokenizer with tests** — `tokenizer.ts` is now a standalone module with 34 vitest tests covering ORP, delays, dash/dot/slash handling, and quote depth tracking