### PR TITLE
Fix layout overflow issues in post edit page

### DIFF
--- a/app/(private)/posts/[slug]/edit/page.tsx
+++ b/app/(private)/posts/[slug]/edit/page.tsx
@@ -203,7 +203,7 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 
 	return (
 		<>
-			<div className="col-span-2 overflow-y-auto py-2">
+			<div className="col-span-2 overflow-y-auto py-2 min-h-0">
 				<div className="flex justify-between items-center">
 					<h1 className="h3">Edit your post</h1>
 					<OptionsMenu postId={initialData.id} slug={initialData.slug} />
@@ -274,7 +274,7 @@ function Client({ initialData }: { initialData: Tables<'posts'> }) {
 					/>
 				</form>
 			</div>
-			<div className="col-span-2 lg:col-span-3 flex flex-col py-2">
+			<div className="col-span-2 lg:col-span-3 flex flex-col py-2 min-h-0 overflow-hidden">
 				<div className="border rounded-lg p-6 pb-16 mx-1 lg:mx-6 overflow-y-auto shadow-lg flex-1 min-h-0">
 					<PostArticle
 						post={thePost}


### PR DESCRIPTION
## Summary
Fixed CSS layout issues in the post edit page that were causing overflow problems with scrollable containers in a grid layout.

## Key Changes
- Added `min-h-0` to the left column container to allow proper flex shrinking in the grid layout
- Added `min-h-0 overflow-hidden` to the right column (preview) container to properly constrain its height and enable scrolling within the nested preview card

## Implementation Details
These changes address a common CSS Grid + Flexbox issue where flex children don't properly respect height constraints. By adding `min-h-0` (equivalent to `min-height: 0`), we override the default `min-height: auto` behavior, allowing the containers to shrink below their content size and properly respect the parent grid's height constraints. The `overflow-hidden` on the preview container ensures that overflow is properly handled at the container level rather than causing layout issues.

https://claude.ai/code/session_01LNj5cCp5vHtXo5vzRiBQXR