### PR TITLE
Refactor project card layout: move image to header as avatar

### DIFF
--- a/app/(public)/projects/page.tsx
+++ b/app/(public)/projects/page.tsx
@@ -54,23 +54,25 @@ export default async function ProjectsPage() {
 							key={project.id}
 							className="border rounded-lg flex flex-col justify-between overflow-hidden hover:shadow-md transition-shadow"
 						>
-							{project.image && (
-								<div className="relative w-full h-40">
-									<Image
-										src={project.image}
-										alt={project.title}
-										fill
-										sizes="(min-width: 640px) 50vw, 100vw"
-										style={{ objectFit: 'cover' }}
-									/>
-								</div>
-							)}
 							<div className="p-6 flex flex-col flex-1 justify-between">
 								<div>
 									<div className="flex items-center justify-between mb-3">
-										<h2 className="text-2xl font-display font-bold text-cyan-content">
-											{project.title}
-										</h2>
+										<div className="flex items-center gap-3">
+											{project.image && (
+												<div className="relative w-12 h-12 shrink-0 rounded-full overflow-hidden border bg-white">
+													<Image
+														src={project.image}
+														alt={project.title}
+														fill
+														sizes="48px"
+														style={{ objectFit: 'contain' }}
+													/>
+												</div>
+											)}
+											<h2 className="text-2xl font-display font-bold text-cyan-content">
+												{project.title}
+											</h2>
+										</div>
 										<div className="flex items-center gap-2">
 											{project.github && (
 												<a

--- a/app/(public)/projects/page.tsx
+++ b/app/(public)/projects/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import Image from 'next/image'
 import Banner from '@/components/banner'
+import IffLoggedIn from '@/app/iff-logged-in'
 import { fetchProjects } from '@/lib/projects'
 
 export const revalidate = 60
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 	description: "Things I've been building",
 }
 
-function ExternalIcon({ className }: { className?: string }) {
+function EditIcon({ className }: { className?: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
@@ -19,11 +20,8 @@ function ExternalIcon({ className }: { className?: string }) {
 			fill="currentColor"
 			className={className ?? 'w-4 h-4'}
 		>
-			<path
-				fillRule="evenodd"
-				d="M4.25 5.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 17h-8.5A2.25 2.25 0 0 1 2 14.75v-8.5A2.25 2.25 0 0 1 4.25 4h5a.75.75 0 0 1 0 1.5h-5Zm7.25-.75a.75.75 0 0 1 .75-.75h3.5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0V6.31l-5.47 5.47a.75.75 0 1 1-1.06-1.06l5.47-5.47H12.25a.75.75 0 0 1-.75-.75Z"
-				clipRule="evenodd"
-			/>
+			<path d="M5.433 13.917l1.262-3.155A4 4 0 0 1 7.58 9.42l6.92-6.918a2.121 2.121 0 0 1 3 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 0 1-.65-.65Z" />
+			<path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0 0 10 3H4.75A2.75 2.75 0 0 0 2 5.75v9.5A2.75 2.75 0 0 0 4.75 18h9.5A2.75 2.75 0 0 0 17 15.25V10a.75.75 0 0 0-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5Z" />
 		</svg>
 	)
 }
@@ -48,6 +46,13 @@ export default async function ProjectsPage() {
 		<>
 			<Banner title="Projects" description="Things I've been building" small />
 			<main className="container py-10">
+				<div className="max-w-4xl mx-auto mb-4 flex justify-end">
+					<IffLoggedIn>
+						<Link href="/projects/manage" className="text-sm text-gray-400 hover:text-gray-600 transition-colors">
+							Manage projects &rarr;
+						</Link>
+					</IffLoggedIn>
+				</div>
 				<div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-4xl mx-auto">
 					{projects?.map((project) => (
 						<div
@@ -85,17 +90,15 @@ export default async function ProjectsPage() {
 													<GithubIcon />
 												</a>
 											)}
-											{project.url?.startsWith('http') && (
-												<a
-													href={project.url}
-													target="_blank"
-													rel="noopener noreferrer"
+											<IffLoggedIn>
+												<Link
+													href={`/projects/${project.id}/edit`}
 													className="text-gray-400 hover:text-gray-600 transition-colors"
-													aria-label={`Visit ${project.title}`}
+													aria-label={`Edit ${project.title}`}
 												>
-													<ExternalIcon className="w-5 h-5" />
-												</a>
-											)}
+													<EditIcon />
+												</Link>
+											</IffLoggedIn>
 										</div>
 									</div>
 									<p className="text-gray-600 leading-relaxed mb-4">
@@ -113,23 +116,25 @@ export default async function ProjectsPage() {
 											</span>
 										))}
 									</div>
+									<div className="flex items-center gap-3 ml-3 shrink-0">
 									{project.url?.startsWith('http') ? (
 										<a
 											href={project.url}
 											target="_blank"
 											rel="noopener noreferrer"
-											className="text-sm font-medium text-cyan-bright hover:underline whitespace-nowrap ml-3"
+											className="text-sm font-medium text-cyan-bright hover:underline whitespace-nowrap"
 										>
 											Visit website &rarr;
 										</a>
 									) : project.url ? (
 										<Link
 											href={project.url}
-											className="text-sm font-medium text-cyan-bright hover:underline whitespace-nowrap ml-3"
+											className="text-sm font-medium text-cyan-bright hover:underline whitespace-nowrap"
 										>
 											Try it out &rarr;
 										</Link>
 									) : null}
+									</div>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
## Summary
Restructured the project card layout to display project images as small circular avatars in the card header next to the title, instead of as large banner images at the top of the card.

## Key Changes
- Removed the full-width image banner (h-40) from the top of project cards
- Moved project image to a small circular avatar (48x48px) positioned next to the project title
- Updated image styling:
  - Changed from `objectFit: 'cover'` to `objectFit: 'contain'` for better logo/icon display
  - Added `rounded-full` for circular appearance
  - Added border and white background for better visual definition
  - Updated `sizes` attribute from responsive viewport widths to fixed "48px"
- Reorganized header layout to use flexbox with gap spacing between avatar and title

## Implementation Details
- The image container now uses `shrink-0` to prevent flex shrinking
- Maintained the conditional rendering of the image (only displays if `project.image` exists)
- The new layout keeps the title and action buttons (GitHub links, etc.) in the same header row

https://claude.ai/code/session_017bjqB31JbuBny4qcGrVdZ1