### PR TITLE
Add Claude hook to suggest fixup commits for feature branches

### DIFF
--- a/.claude/hooks/suggest-fixup-commit.sh
+++ b/.claude/hooks/suggest-fixup-commit.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# suggest-fixup-commit.sh — Before git commit, check if this should be a fixup.
+#
+# ADVISORY (exit 0): This hook suggests but does not block.
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+if ! echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+commit\b'; then
+  exit 0
+fi
+if echo "$COMMAND" | grep -qE -- '--(fixup|squash|amend)'; then
+  exit 0
+fi
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ]; then
+  exit 0
+fi
+MAIN_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$MAIN_BRANCH" ]; then
+  MAIN_BRANCH=$(git remote show origin 2>/dev/null | awk '/HEAD branch/ {print $NF}')
+fi
+if [ -z "$MAIN_BRANCH" ]; then
+  for candidate in main master next develop; do
+    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+      MAIN_BRANCH=$candidate
+      break
+    fi
+  done
+fi
+if [ -z "$MAIN_BRANCH" ]; then
+  exit 0
+fi
+UNMERGED=$(git log "origin/$MAIN_BRANCH..HEAD" --oneline 2>/dev/null | head -10)
+if [ -z "$UNMERGED" ]; then
+  exit 0
+fi
+COUNT=$(echo "$UNMERGED" | wc -l | tr -d ' ')
+echo "FIXUP CHECK: Before creating a new commit, ask yourself:"
+echo "  Is this commit fixing, completing, or amending a recent commit on this branch?"
+echo ""
+echo "Unmerged commits on '$BRANCH' ($COUNT):"
+echo "$UNMERGED" | sed 's/^/  /'
+echo ""
+echo "If yes → use:  git commit --fixup=<hash>"
+echo "  (then run 'git rebase -i --autosquash origin/$MAIN_BRANCH' to squash before merging)"
+echo ""
+echo "Only create a new standalone commit if it's genuinely independent work."
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/suggest-fixup-commit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a pre-commit hook that suggests using `git commit --fixup` when committing to a feature branch with unmerged commits, helping maintain cleaner commit histories before merging.

## Changes
- **New hook script** (`.claude/hooks/suggest-fixup-commit.sh`): Detects when a user is about to create a regular commit on a feature branch and suggests using `--fixup` if there are recent unmerged commits. The hook:
  - Intercepts `git commit` commands before execution
  - Identifies the main branch (origin/HEAD, or falls back to main/master/next/develop)
  - Lists unmerged commits on the current branch
  - Provides guidance on using `git commit --fixup` and `git rebase -i --autosquash`
  - Operates as an advisory only (exits with 0, does not block commits)

- **New configuration** (`.claude/settings.json`): Registers the hook to run before Bash tool execution, enabling Claude to suggest fixup commits during development workflows

## Implementation Details
- The hook reads tool input via JSON to detect `git commit` commands
- Gracefully handles missing git configuration or empty branches
- Attempts multiple strategies to identify the main branch for maximum compatibility
- Provides clear, actionable output without being intrusive

https://claude.ai/code/session_013SJzEiqVaMbrkYgTpHyzRv