### PR TITLE
Add custom error and not found pages to router

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,11 +1,17 @@
 import { createRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
+import NotFoundPage from '@/components/not-found-page'
+import ErrorPage from '@/components/error-page'
 
 export function getRouter() {
 	return createRouter({
 		routeTree,
 		scrollRestoration: true,
 		defaultPreload: 'intent',
+		// Router-wide defaults so unmatched URLs land on our styled pages
+		// instead of TanStack's bare `<p>Not Found</p>` stub.
+		defaultNotFoundComponent: NotFoundPage,
+		defaultErrorComponent: ErrorPage,
 	})
 }
 


### PR DESCRIPTION
## Summary
Configure the TanStack router to use custom styled error and not found pages instead of the default bare placeholder components.

## Changes
- Import `NotFoundPage` and `ErrorPage` components
- Set `defaultNotFoundComponent` to use the custom `NotFoundPage` for unmatched URLs
- Set `defaultErrorComponent` to use the custom `ErrorPage` for router errors
- These router-wide defaults ensure consistent error handling across the application

## Implementation Details
The custom components are now applied at the router configuration level, providing a better user experience when users encounter 404s or other routing errors by displaying styled pages instead of TanStack Router's default minimal `<p>Not Found</p>` stub.

https://claude.ai/code/session_01QgqdQfavzCjhyffdVKMEs6